### PR TITLE
Set vesc_driver library files to be built as libraries

### DIFF
--- a/vesc_driver/CMakeLists.txt
+++ b/vesc_driver/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_package(
   INCLUDE_DIRS include
+  LIBRARIES vesc_driver
   CATKIN_DEPENDS nodelet pluginlib roscpp std_msgs vesc_msgs serial
 )
 
@@ -27,31 +28,36 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
+add_library(vesc_driver
+  src/vesc_driver.cpp
+  src/vesc_interface.cpp
+  src/vesc_packet.cpp
+  src/vesc_packet_factory.cpp
+)
+
 # node executable
-add_executable(vesc_driver_node src/vesc_driver_node.cpp
-                                src/vesc_driver.cpp
-                                src/vesc_interface.cpp
-                                src/vesc_packet.cpp
-                                src/vesc_packet_factory.cpp)
+add_executable(vesc_driver_node src/vesc_driver_node.cpp)
 add_dependencies(vesc_driver_node ${catkin_EXPORTED_TARGETS})
 target_link_libraries(vesc_driver_node
+  vesc_driver
   ${catkin_LIBRARIES}
 )
 
 # nodelet library
-add_library(vesc_driver_nodelet src/vesc_driver_nodelet.cpp
-                                src/vesc_driver.cpp
-                                src/vesc_interface.cpp
-                                src/vesc_packet.cpp
-                                src/vesc_packet_factory.cpp)
+add_library(vesc_driver_nodelet src/vesc_driver_nodelet.cpp)
 add_dependencies(vesc_driver_nodelet ${catkin_EXPORTED_TARGETS})
 target_link_libraries(vesc_driver_nodelet
+  vesc_driver
   ${catkin_LIBRARIES}
 )
 
 #############
 ## Install ##
 #############
+
+install(TARGETS vesc_driver
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
 
 install(TARGETS vesc_driver_node
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/vesc_driver/CMakeLists.txt
+++ b/vesc_driver/CMakeLists.txt
@@ -28,6 +28,7 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
+# driver libraries
 add_library(vesc_driver
   src/vesc_driver.cpp
   src/vesc_interface.cpp
@@ -67,15 +68,14 @@ install(TARGETS vesc_driver_nodelet
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+install(DIRECTORY include/${PROJECT_NAME}
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
 install(FILES vesc_driver_nodelet.xml
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-install(DIRECTORY launch/
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 
-#############
-## Testing ##
-#############
-
-# TODO
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)


### PR DESCRIPTION
In `vesc_driver` package, following files are built just as linked files to its node and nodelet.

* `src/vesc_driver.cpp`
* `src/vesc_interface.cpp`
* `src/vesc_packet.cpp`
* `src/vesc_packet_factory.cpp`

However, they should be built as libraries in order to be linked in other packages for expanded applications. This PR contributes to realize that by editing `CMakeLists.txt`.