### PR TITLE
Change vesc_hi package structure to build as a library

### DIFF
--- a/vesc_hi/CMakeLists.txt
+++ b/vesc_hi/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_package(
   INCLUDE_DIRS include
+  LIBRARIES vesc_hi
   CATKIN_DEPENDS roscpp serial hardware_interface controller_manager vesc_driver
 )
 
@@ -22,9 +23,19 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-add_executable(vesc_hi
+add_library(vesc_hi
   src/vesc_hi.cpp
   src/vesc_servo_controller.cpp
 )
 add_dependencies(vesc_hi ${catkin_EXPORTED_TARGETS})
 target_link_libraries(vesc_hi ${catkin_LIBRARIES})
+
+add_executable(vesc_hi_node
+  src/vesc_hi_node.cpp
+)
+add_dependencies(vesc_hi_node ${catkin_EXPORTED_TARGETS})
+target_link_libraries(vesc_hi_node ${catkin_LIBRARIES} vesc_hi)
+
+install(DIRECTORY include/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)

--- a/vesc_hi/src/vesc_hi.cpp
+++ b/vesc_hi/src/vesc_hi.cpp
@@ -18,38 +18,6 @@
 
 #include "vesc_hi/vesc_hi.h"
 
-int main(int argc, char** argv) {
-    ros::init(argc, argv, "vesc_hi");
-
-    ros::NodeHandle nh, nh_private("~");
-    vesc_hi::VescHI vesc_hi(nh_private);
-
-    controller_manager::ControllerManager controller_manager(&vesc_hi, nh);
-
-    ros::Rate         loop_rate(1.0 / vesc_hi.getPeriod().toSec());
-    ros::AsyncSpinner spinner(1);
-
-    spinner.start();
-
-    while(ros::ok()) {
-        // sends commands
-        vesc_hi.read();
-
-        // updates the hardware interface control
-        controller_manager.update(vesc_hi.getTime(), vesc_hi.getPeriod());
-
-        // gets current states
-        vesc_hi.write();
-
-        // sleeps
-        loop_rate.sleep();
-    }
-
-    spinner.stop();
-
-    return 0;
-}
-
 namespace vesc_hi {
 
 VescHI::VescHI(ros::NodeHandle nh)

--- a/vesc_hi/src/vesc_hi.cpp
+++ b/vesc_hi/src/vesc_hi.cpp
@@ -26,7 +26,7 @@ VescHI::VescHI(ros::NodeHandle nh)
     , servo_controller_(nh, &vesc_interface_, 1.0 / getPeriod().toSec()) {
     // reads a port name to open
     std::string port;
-    if(!nh.getParam("port", port)) {
+    if(!nh.getParam("vesc_hi/port", port)) {
         ROS_FATAL("VESC communication port parameter required.");
         ros::shutdown();
     }
@@ -41,7 +41,7 @@ VescHI::VescHI(ros::NodeHandle nh)
     }
 
     // initializes joint names
-    nh.param<std::string>("joint_name", joint_name_, "joint_vesc");
+    nh.param<std::string>("vesc_hi/joint_name", joint_name_, "joint_vesc");
 
     // initializes commands and states
     command_  = 0.0;
@@ -50,11 +50,12 @@ VescHI::VescHI(ros::NodeHandle nh)
     effort_   = 0.0;
 
     // reads system parameters
-    nh.param<double>("gear_ratio", gear_ratio_, 1.0);
-    nh.param<double>("torque_const", torque_const_, 1.0);
+    nh.param<double>("vesc_hi/gear_ratio", gear_ratio_, 1.0);
+    nh.param<double>("vesc_hi/torque_const", torque_const_, 1.0);
 
     // reads driving mode setting
-    nh.param<std::string>("command_mode", command_mode_, "");  // assigns an empty string if param. is not found
+    nh.param<std::string>("vesc_hi/command_mode", command_mode_, "");  // assigns an empty string if param. is not found
+    ROS_INFO("mode: %s", command_mode_.data());
 
     // registers a state handle and its interface
     hardware_interface::JointStateHandle state_handle(joint_name_, &position_, &velocity_, &effort_);

--- a/vesc_hi/src/vesc_hi_node.cpp
+++ b/vesc_hi/src/vesc_hi_node.cpp
@@ -1,0 +1,51 @@
+/*********************************************************************
+*
+* Copyright (c) 2019, SoftBank corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*********************************************************************/
+
+#include "vesc_hi/vesc_hi.h"
+
+int main(int argc, char** argv) {
+    ros::init(argc, argv, "vesc_hi");
+
+    ros::NodeHandle nh, nh_private("~");
+    vesc_hi::VescHI vesc_hi(nh_private);
+
+    controller_manager::ControllerManager controller_manager(&vesc_hi, nh);
+
+    ros::Rate         loop_rate(1.0 / vesc_hi.getPeriod().toSec());
+    ros::AsyncSpinner spinner(1);
+
+    spinner.start();
+
+    while(ros::ok()) {
+        // sends commands
+        vesc_hi.read();
+
+        // updates the hardware interface control
+        controller_manager.update(vesc_hi.getTime(), vesc_hi.getPeriod());
+
+        // gets current states
+        vesc_hi.write();
+
+        // sleeps
+        loop_rate.sleep();
+    }
+
+    spinner.stop();
+
+    return 0;
+}

--- a/vesc_hi/src/vesc_servo_controller.cpp
+++ b/vesc_hi/src/vesc_servo_controller.cpp
@@ -33,10 +33,10 @@ VescServoController::VescServoController(ros::NodeHandle nh, VescInterface* inte
     frequency_        = frequency;
 
     // reads parameters
-    nh.param("servo/Kp", Kp_, 50.0);
-    nh.param("servo/Ki", Ki_, 0.0);
-    nh.param("servo/Kd", Kd_, 1.0);
-    nh.param("servo/calibration_current", calibration_current_, 6.0);
+    nh.param("vesc_hi/servo/Kp", Kp_, 50.0);
+    nh.param("vesc_hi/servo/Ki", Ki_, 0.0);
+    nh.param("vesc_hi/servo/Kd", Kd_, 1.0);
+    nh.param("vesc_hi/servo/calibration_current", calibration_current_, 6.0);
 }
 
 void VescServoController::control(const double position_reference, double position_current) {


### PR DESCRIPTION
To integrate easily, I change build options in CMakeLists.txt and separate the main function of the node from library files.

The new node name is `vesc_hi_node` and `vesc_hi` becomes a library name.