### PR TITLE
Add respawn options to <node>

### DIFF
--- a/vesc_driver/launch/vesc_driver_nodelet.launch
+++ b/vesc_driver/launch/vesc_driver_nodelet.launch
@@ -21,13 +21,13 @@
 
   <!-- Nodelet manager -->
   <node if="$(arg start_manager)" pkg="nodelet" type="nodelet" name="$(arg manager)"
-        args="manager" output="screen" launch-prefix="$(arg launch_prefix)">
+        args="manager" output="screen" launch-prefix="$(arg launch_prefix)" respawn="true">
      <param name="num_worker_threads" value="$(arg num_worker_threads)" />
   </node>
 
   <!-- VESC driver nodelet -->
   <node pkg="nodelet" type="nodelet" name="$(arg node_name)"
-        args="load vesc_driver::VescDriverNodelet $(arg manager)" >
+        args="load vesc_driver::VescDriverNodelet $(arg manager)" respawn="true">
     <param name="port" value="$(arg port)" />
   </node>    
 


### PR DESCRIPTION
VESCが落ちてしまったあと、/dev/ttyVESC_xx があるときに再起動できるようにrespawnオプションを追加した
### 実験
- VESCに刺さっているMicro USBを抜いてVESC nodeが落ちてDiagnosticでエラーを確認してから、再度挿し直した→DiagのErrorが消えた
- tfの監視→/base/base_driverからはOdom tfの出力確認
- teleopで動作中抜き差しした→VESC nodeが再起動して移動できた
- Move_base中に抜き差しした→自立移動を開始し、自己位置もバグらなかった