### PR TITLE
Hardware interface export

### DIFF
--- a/vesc_hi/CMakeLists.txt
+++ b/vesc_hi/CMakeLists.txt
@@ -8,13 +8,20 @@ find_package(catkin REQUIRED COMPONENTS
   serial
   hardware_interface
   controller_manager
+  pluginlib
   vesc_driver
 )
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES vesc_hi
-  CATKIN_DEPENDS roscpp serial hardware_interface controller_manager vesc_driver
+  CATKIN_DEPENDS
+    roscpp
+    serial
+    hardware_interface
+    controller_manager
+    pluginlib
+    vesc_driver
 )
 
 include_directories(

--- a/vesc_hi/CMakeLists.txt
+++ b/vesc_hi/CMakeLists.txt
@@ -13,8 +13,10 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES vesc_hi
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    vesc_hi
   CATKIN_DEPENDS
     roscpp
     serial
@@ -43,6 +45,14 @@ add_executable(vesc_hi_node
 add_dependencies(vesc_hi_node ${catkin_EXPORTED_TARGETS})
 target_link_libraries(vesc_hi_node ${catkin_LIBRARIES} vesc_hi)
 
+install(TARGETS vesc_hi
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
 install(DIRECTORY include/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+install(DIRECTORY launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
 )

--- a/vesc_hi/include/vesc_hi/vesc_hi.h
+++ b/vesc_hi/include/vesc_hi/vesc_hi.h
@@ -32,6 +32,7 @@
 #include <hardware_interface/joint_state_interface.h>
 #include <hardware_interface/joint_command_interface.h>
 #include <controller_manager/controller_manager.h>
+#include <pluginlib/class_list_macros.hpp>
 
 #include "vesc_driver/vesc_packet.h"
 #include "vesc_driver/vesc_packet_factory.h"
@@ -51,7 +52,9 @@ public:
 
     bool          init(ros::NodeHandle&, ros::NodeHandle&);
     void          read();
+    void          read(const ros::Time&, const ros::Duration&);
     void          write();
+    void          write(const ros::Time&, const ros::Duration&);
     ros::Time     getTime() const;
     ros::Duration getPeriod() const;
 
@@ -59,7 +62,7 @@ private:
     VescInterface       vesc_interface_;
     VescServoController servo_controller_;
 
-    std::string         joint_name_, command_mode_;
+    std::string joint_name_, command_mode_;
 
     double command_;
     double position_, velocity_, effort_;  // joint states

--- a/vesc_hi/include/vesc_hi/vesc_hi.h
+++ b/vesc_hi/include/vesc_hi/vesc_hi.h
@@ -46,9 +46,10 @@ using vesc_driver::VescInterface;
 
 class VescHI : public hardware_interface::RobotHW {
 public:
-    explicit VescHI(ros::NodeHandle);
+    VescHI();
     ~VescHI();
 
+    bool          init(ros::NodeHandle&, ros::NodeHandle&);
     void          read();
     void          write();
     ros::Time     getTime() const;

--- a/vesc_hi/include/vesc_hi/vesc_servo_controller.h
+++ b/vesc_hi/include/vesc_hi/vesc_servo_controller.h
@@ -30,8 +30,7 @@ using vesc_driver::VescInterface;
 
 class VescServoController {
 public:
-    explicit VescServoController(ros::NodeHandle, VescInterface*, const double);
-
+    void   init(ros::NodeHandle, VescInterface*, const double);
     void   control(const double, const double);
     double getZeroPosition();
     void   executeCalibration();

--- a/vesc_hi/package.xml
+++ b/vesc_hi/package.xml
@@ -13,11 +13,6 @@
   <depend>serial</depend>
   <depend>hardware_interface</depend>
   <depend>controller_manager</depend>
+  <depend>pluginlib</depend>
   <depend>vesc_driver</depend>
-
-  <exec_depend>position_controllers</exec_depend>
-  <exec_depend>velocity_controllers</exec_depend>
-  <exec_depend>effort_controllers</exec_depend>
-  <exec_depend>joint_trajectory_controller</exec_depend>
-  <exec_depend>joint_state_controller</exec_depend>
 </package>

--- a/vesc_hi/package.xml
+++ b/vesc_hi/package.xml
@@ -15,4 +15,8 @@
   <depend>controller_manager</depend>
   <depend>pluginlib</depend>
   <depend>vesc_driver</depend>
+
+  <export>
+    <hardware_interface plugin="${prefix}/vesc_hi_plugin.xml"/>
+  </export>
 </package>

--- a/vesc_hi/src/vesc_hi.cpp
+++ b/vesc_hi/src/vesc_hi.cpp
@@ -116,6 +116,11 @@ void VescHI::read() {
     return;
 }
 
+void VescHI::read(const ros::Time& time, const ros::Duration& period) {
+    read();
+    return;
+}
+
 void VescHI::write() {
     // requests joint states
     // function `packetCallback` will be called after receiveing retrun packets
@@ -124,6 +129,11 @@ void VescHI::write() {
     // updates zero position
     zero_position_val_ = gear_ratio_ * servo_controller_.getZeroPosition();
 
+    return;
+}
+
+void VescHI::write(const ros::Time& time, const ros::Duration& period) {
+    write();
     return;
 }
 
@@ -157,3 +167,5 @@ void VescHI::errorCallback(const std::string& error) {
 }
 
 }  // namespace vesc_hi
+
+PLUGINLIB_EXPORT_CLASS(vesc_hi::VescHI, hardware_interface::RobotHW)

--- a/vesc_hi/src/vesc_hi.cpp
+++ b/vesc_hi/src/vesc_hi.cpp
@@ -20,10 +20,15 @@
 
 namespace vesc_hi {
 
-VescHI::VescHI(ros::NodeHandle nh)
+VescHI::VescHI()
     : vesc_interface_(std::string(), boost::bind(&VescHI::packetCallback, this, _1),
-                      boost::bind(&VescHI::errorCallback, this, _1))
-    , servo_controller_(nh, &vesc_interface_, 1.0 / getPeriod().toSec()) {
+                      boost::bind(&VescHI::errorCallback, this, _1)) {
+}
+
+VescHI::~VescHI() {
+}
+
+bool VescHI::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh) {
     // reads a port name to open
     std::string port;
     if(!nh.getParam("vesc_hi/port", port)) {
@@ -36,8 +41,8 @@ VescHI::VescHI(ros::NodeHandle nh)
         vesc_interface_.connect(port);
     } catch(serial::SerialException exception) {
         ROS_FATAL("Failed to connect to the VESC, %s.", exception.what());
-        ros::shutdown();
-        return;
+        // ros::shutdown();
+        return false;
     }
 
     // initializes joint names
@@ -67,6 +72,9 @@ VescHI::VescHI(ros::NodeHandle nh)
         hardware_interface::JointHandle position_handle(joint_state_interface_.getHandle(joint_name_), &command_);
         joint_position_interface_.registerHandle(position_handle);
         registerInterface(&joint_position_interface_);
+
+        // initializes the servo controller
+        servo_controller_.init(nh, &vesc_interface_, 1.0 / getPeriod().toSec());
     } else if(command_mode_ == "velocity") {
         hardware_interface::JointHandle velocity_handle(joint_state_interface_.getHandle(joint_name_), &command_);
         joint_velocity_interface_.registerHandle(velocity_handle);
@@ -77,11 +85,11 @@ VescHI::VescHI(ros::NodeHandle nh)
         registerInterface(&joint_effort_interface_);
     } else {
         ROS_ERROR("Verify your command mode setting");
-        ros::shutdown();
+        // ros::shutdown();
+        return false;
     }
-}
 
-VescHI::~VescHI() {
+    return true;
 }
 
 void VescHI::read() {

--- a/vesc_hi/src/vesc_hi_node.cpp
+++ b/vesc_hi/src/vesc_hi_node.cpp
@@ -19,10 +19,11 @@
 #include "vesc_hi/vesc_hi.h"
 
 int main(int argc, char** argv) {
-    ros::init(argc, argv, "vesc_hi");
+    ros::init(argc, argv, "vesc_hi_node");
 
     ros::NodeHandle nh, nh_private("~");
-    vesc_hi::VescHI vesc_hi(nh_private);
+    vesc_hi::VescHI vesc_hi;
+    vesc_hi.init(nh, nh_private);
 
     controller_manager::ControllerManager controller_manager(&vesc_hi, nh);
 

--- a/vesc_hi/src/vesc_servo_controller.cpp
+++ b/vesc_hi/src/vesc_servo_controller.cpp
@@ -20,7 +20,7 @@
 
 namespace vesc_hi {
 
-VescServoController::VescServoController(ros::NodeHandle nh, VescInterface* interface_ptr, const double frequency) {
+void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr, const double frequency) {
     // initializes members
     if(interface_ptr == NULL) {
         ros::shutdown();
@@ -37,6 +37,8 @@ VescServoController::VescServoController(ros::NodeHandle nh, VescInterface* inte
     nh.param("vesc_hi/servo/Ki", Ki_, 0.0);
     nh.param("vesc_hi/servo/Kd", Kd_, 1.0);
     nh.param("vesc_hi/servo/calibration_current", calibration_current_, 6.0);
+
+    return;
 }
 
 void VescServoController::control(const double position_reference, double position_current) {

--- a/vesc_hi/vesc_hi_plugin.xml
+++ b/vesc_hi/vesc_hi_plugin.xml
@@ -1,0 +1,7 @@
+<library path="lib/libvesc_hi">
+  <class name="vesc_hi/VescHI" type="vesc_hi::VescHI" base_class_type="hardware_interface::RobotHW">
+    <description>
+        plugin of VESC hardware interface
+    </description>
+  </class>
+</library>


### PR DESCRIPTION
In order to export this hardware interface, I separate initialization processes from the constructor of `VescHI` and create `init` function instead.