### PR TITLE
Enable to set a calibrtion point safely

### DIFF
--- a/vesc_hw_interface/CMakeLists.txt
+++ b/vesc_hw_interface/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   serial
   hardware_interface
+  joint_limits_interface
   controller_manager
   pluginlib
   urdf
@@ -22,6 +23,7 @@ catkin_package(
     roscpp
     serial
     hardware_interface
+    joint_limits_interface
     controller_manager
     pluginlib
     urdf

--- a/vesc_hw_interface/CMakeLists.txt
+++ b/vesc_hw_interface/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   hardware_interface
   controller_manager
   pluginlib
+  urdf
   vesc_driver
 )
 
@@ -23,6 +24,7 @@ catkin_package(
     hardware_interface
     controller_manager
     pluginlib
+    urdf
     vesc_driver
 )
 

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
@@ -67,7 +67,7 @@ private:
     double command_;
     double position_, velocity_, effort_;  // joint states
 
-    double zero_position_val_;          // sensor value on zero position
+    double zero_position_pulse_;        // sensor value on zero position
     double gear_ratio_, torque_const_;  // physical params.
 
     hardware_interface::JointStateInterface    joint_state_interface_;

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
@@ -67,7 +67,6 @@ private:
     double command_;
     double position_, velocity_, effort_;  // joint states
 
-    double zero_position_pulse_;        // sensor value on zero position
     double gear_ratio_, torque_const_;  // physical params.
 
     hardware_interface::JointStateInterface    joint_state_interface_;

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
@@ -31,6 +31,10 @@
 #include <hardware_interface/robot_hw.h>
 #include <hardware_interface/joint_state_interface.h>
 #include <hardware_interface/joint_command_interface.h>
+#include <joint_limits_interface/joint_limits.h>
+#include <joint_limits_interface/joint_limits_interface.h>
+#include <joint_limits_interface/joint_limits_rosparam.h>
+#include <joint_limits_interface/joint_limits_urdf.h>
 #include <controller_manager/controller_manager.h>
 #include <pluginlib/class_list_macros.hpp>
 #include <urdf_parser/urdf_parser.h>
@@ -74,6 +78,11 @@ private:
     hardware_interface::PositionJointInterface joint_position_interface_;
     hardware_interface::VelocityJointInterface joint_velocity_interface_;
     hardware_interface::EffortJointInterface   joint_effort_interface_;
+
+    joint_limits_interface::JointLimits                      joint_limits_;
+    joint_limits_interface::PositionJointSaturationInterface limit_position_interface_;
+    joint_limits_interface::VelocityJointSaturationInterface limit_velocity_interface_;
+    joint_limits_interface::EffortJointSaturationInterface   limit_effort_interface_;
 
     void packetCallback(const boost::shared_ptr<VescPacket const>&);
     void errorCallback(const std::string&);

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
@@ -33,6 +33,7 @@
 #include <hardware_interface/joint_command_interface.h>
 #include <controller_manager/controller_manager.h>
 #include <pluginlib/class_list_macros.hpp>
+#include <urdf_parser/urdf_parser.h>
 
 #include "vesc_driver/vesc_packet.h"
 #include "vesc_driver/vesc_packet_factory.h"

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -32,7 +32,7 @@ class VescServoController {
 public:
     void   init(ros::NodeHandle, VescInterface*, const double);
     void   control(const double, const double);
-    double getZeroPosition();
+    double getZeroPosition() const;
     void   executeCalibration();
 
 private:
@@ -43,8 +43,8 @@ private:
     double Kp_, Ki_, Kd_, frequency_;
 
     bool   calibrate(const double);
-    bool   isSaturated(const double);
-    double saturate(const double);
+    bool   isSaturated(const double) const;
+    double saturate(const double) const;
 };
 
 }  // namespace vesc_hw_interface

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -39,7 +39,9 @@ private:
     VescInterface* interface_ptr_;
 
     bool   calibration_flag_;
-    double calibration_current_, zero_position_;
+    double calibration_current_;   // unit: A
+    double calibration_position_;  // unit: rad or m
+    double zero_position_;         // unit: rad or m
     double Kp_, Ki_, Kd_, frequency_;
 
     bool   calibrate(const double);

--- a/vesc_hw_interface/package.xml
+++ b/vesc_hw_interface/package.xml
@@ -14,6 +14,7 @@
   <depend>hardware_interface</depend>
   <depend>controller_manager</depend>
   <depend>pluginlib</depend>
+  <depend>urdf</depend>
   <depend>vesc_driver</depend>
 
   <export>

--- a/vesc_hw_interface/package.xml
+++ b/vesc_hw_interface/package.xml
@@ -12,6 +12,7 @@
   <depend>roscpp</depend>
   <depend>serial</depend>
   <depend>hardware_interface</depend>
+  <depend>joint_limits_interface</depend>
   <depend>controller_manager</depend>
   <depend>pluginlib</depend>
   <depend>urdf</depend>

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -94,6 +94,19 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh) {
 }
 
 void VescHwInterface::read() {
+    // requests joint states
+    // function `packetCallback` will be called after receiveing retrun packets
+    vesc_interface_.requestState();
+
+    return;
+}
+
+void VescHwInterface::read(const ros::Time& time, const ros::Duration& period) {
+    read();
+    return;
+}
+
+void VescHwInterface::write() {
     // sends commands
     if(command_mode_ == "position") {
         // executes PID control
@@ -114,19 +127,6 @@ void VescHwInterface::read() {
         // sends a  duty command
         vesc_interface_.setDutyCycle(command_);
     }
-    return;
-}
-
-void VescHwInterface::read(const ros::Time& time, const ros::Duration& period) {
-    read();
-    return;
-}
-
-void VescHwInterface::write() {
-    // requests joint states
-    // function `packetCallback` will be called after receiveing retrun packets
-    vesc_interface_.requestState();
-
     return;
 }
 

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -59,7 +59,8 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh) {
     nh.param<double>("vesc_hw_interface/torque_const", torque_const_, 1.0);
 
     // reads driving mode setting
-    nh.param<std::string>("vesc_hw_interface/command_mode", command_mode_, "");  // assigns an empty string if param. is not found
+    // - assigns an empty string if param. is not found
+    nh.param<std::string>("vesc_hw_interface/command_mode", command_mode_, "");
     ROS_INFO("mode: %s", command_mode_.data());
 
     // registers a state handle and its interface

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -127,9 +127,6 @@ void VescHwInterface::write() {
     // function `packetCallback` will be called after receiveing retrun packets
     vesc_interface_.requestState();
 
-    // updates zero position
-    zero_position_pulse_ = gear_ratio_ * servo_controller_.getZeroPosition();
-
     return;
 }
 
@@ -154,7 +151,7 @@ void VescHwInterface::packetCallback(const boost::shared_ptr<VescPacket const>& 
         double velocity_rpm   = values->getRpm();
         double position_pulse = values->getPosition();
 
-        position_ = (position_pulse - zero_position_pulse_) / gear_ratio_;  // unit: rad or m
+        position_ = position_pulse / gear_ratio_ - servo_controller_.getZeroPosition();  // unit: rad or m
         velocity_ = velocity_rpm * 2 * M_PI / 60.0 / gear_ratio_;           // unit: rad/s or m/s
         effort_   = current * torque_const_ * gear_ratio_;                  // unit: Nm or N
     }

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -45,8 +45,22 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh) {
         return false;
     }
 
-    // initializes joint names
+    // initializes the joint name
     nh.param<std::string>("vesc_hw_interface/joint_name", joint_name_, "joint_vesc");
+
+    // loads joint limits
+    std::string robot_description_name, robot_description;
+    nh.param<std::string>("vesc_hw_interface/robot_description_name", robot_description_name, "/robot_description");
+
+    // parses the urdf
+    if(nh.getParam(robot_description_name, robot_description)) {
+        boost::shared_ptr<urdf::ModelInterface> urdf       = urdf::parseURDF(robot_description);
+        boost::shared_ptr<const urdf::Joint>    urdf_joint = urdf->getJoint(joint_name_);
+
+        if(getJointLimits(urdf_joint, joint_limits_)) {
+            ROS_INFO("Joint limits are loaded");
+        }
+    }
 
     // initializes commands and states
     command_  = 0.0;

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -127,7 +127,7 @@ void VescHwInterface::write() {
     vesc_interface_.requestState();
 
     // updates zero position
-    zero_position_val_ = gear_ratio_ * servo_controller_.getZeroPosition();
+    zero_position_pulse_ = gear_ratio_ * servo_controller_.getZeroPosition();
 
     return;
 }
@@ -153,9 +153,9 @@ void VescHwInterface::packetCallback(const boost::shared_ptr<VescPacket const>& 
         double velocity_rpm   = values->getRpm();
         double position_pulse = values->getPosition();
 
-        position_ = (position_pulse - zero_position_val_) / gear_ratio_;  // unit: rad or m
-        velocity_ = velocity_rpm * 2 * M_PI / 60.0 / gear_ratio_;         // unit: rad/s or m/s
-        effort_   = current * torque_const_ * gear_ratio_;                // unit: Nm or N
+        position_ = (position_pulse - zero_position_pulse_) / gear_ratio_;  // unit: rad or m
+        velocity_ = velocity_rpm * 2 * M_PI / 60.0 / gear_ratio_;           // unit: rad/s or m/s
+        effort_   = current * torque_const_ * gear_ratio_;                  // unit: Nm or N
     }
 
     return;

--- a/vesc_hw_interface/src/vesc_hw_interface_node.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface_node.cpp
@@ -34,13 +34,13 @@ int main(int argc, char** argv) {
 
     while(ros::ok()) {
         // sends commands
-        vesc_hw_interface.read();
+        vesc_hw_interface.write();
 
         // updates the hardware interface control
         controller_manager.update(vesc_hw_interface.getTime(), vesc_hw_interface.getPeriod());
 
         // gets current states
-        vesc_hw_interface.write();
+        vesc_hw_interface.read();
 
         // sleeps
         loop_rate.sleep();

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -41,7 +41,7 @@ void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr,
     return;
 }
 
-void VescServoController::control(const double position_reference, double position_current) {
+void VescServoController::control(const double position_reference, const double position_current) {
     // executes caribration
     if(calibration_flag_) {
         calibrate(position_current);
@@ -83,7 +83,7 @@ void VescServoController::control(const double position_reference, double positi
     return;
 }
 
-double VescServoController::getZeroPosition() {
+double VescServoController::getZeroPosition() const {
     return zero_position_;
 }
 
@@ -118,7 +118,7 @@ bool VescServoController::calibrate(const double position_current) {
     }
 }
 
-bool VescServoController::isSaturated(const double arg) {
+bool VescServoController::isSaturated(const double arg) const {
     if(std::abs(arg) > 1.0) {
         return true;
     } else {
@@ -126,7 +126,7 @@ bool VescServoController::isSaturated(const double arg) {
     }
 }
 
-double VescServoController::saturate(const double arg) {
+double VescServoController::saturate(const double arg) const {
     if(arg > 1.0) {
         return 1.0;
     } else if(arg < -1.0) {

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -37,6 +37,7 @@ void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr,
     nh.param("vesc_hw_interface/servo/Ki", Ki_, 0.0);
     nh.param("vesc_hw_interface/servo/Kd", Kd_, 1.0);
     nh.param("vesc_hw_interface/servo/calibration_current", calibration_current_, 6.0);
+    nh.param("vesc_hw_interface/servo/calibration_position", calibration_position_, 0.0);
 
     return;
 }
@@ -106,7 +107,7 @@ bool VescServoController::calibrate(const double position_current) {
         interface_ptr_->setCurrent(0.0);
         calibration_flag_ = false;
         step              = 0;
-        zero_position_    = position_current;
+        zero_position_    = position_current - calibration_position_;
 
         ROS_INFO("Calibration Finished");
         return true;


### PR DESCRIPTION
This PR includes
- adding options to set a calibration point if it is not zero, and 
- limiting commands with referring to the robot description file (URDF).

The latter is based on `joint_limit_interface` libs.