### PR TITLE
Reduce boost dependencies

### DIFF
--- a/vesc_driver/include/vesc_driver/vesc_driver.h
+++ b/vesc_driver/include/vesc_driver/vesc_driver.h
@@ -36,13 +36,14 @@
 #ifndef VESC_DRIVER_VESC_DRIVER_H_
 #define VESC_DRIVER_VESC_DRIVER_H_
 
-#include <string>
 #include <cassert>
 #include <cmath>
+#include <memory>
 #include <sstream>
+#include <string>
 
-#include <boost/optional.hpp>
 #include <boost/bind.hpp>
+#include <boost/optional.hpp>
 
 #include <ros/ros.h>
 #include <std_msgs/Float64.h>
@@ -61,7 +62,7 @@ public:
 private:
   // interface to the VESC
   VescInterface vesc_;
-  void vescPacketCallback(const boost::shared_ptr<VescPacket const>& packet);
+  void vescPacketCallback(const std::shared_ptr<VescPacket const>& packet);
   void vescErrorCallback(const std::string& error);
 
   // limits on VESC commands

--- a/vesc_driver/include/vesc_driver/vesc_driver.h
+++ b/vesc_driver/include/vesc_driver/vesc_driver.h
@@ -38,11 +38,11 @@
 
 #include <cassert>
 #include <cmath>
+#include <functional>
 #include <memory>
 #include <sstream>
 #include <string>
 
-#include <boost/bind.hpp>
 #include <boost/optional.hpp>
 
 #include <ros/ros.h>

--- a/vesc_driver/include/vesc_driver/vesc_interface.h
+++ b/vesc_driver/include/vesc_driver/vesc_interface.h
@@ -49,7 +49,6 @@
 #include <serial/serial.h>
 #include <boost/crc.hpp>
 #include <boost/noncopyable.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include "vesc_driver/vesc_packet.h"
 #include "vesc_driver/vesc_packet_factory.h"
@@ -132,7 +131,7 @@ public:
 private:
   // Pimpl - hide serial port members from class users
   class Impl;
-  boost::scoped_ptr<Impl> impl_;
+  std::unique_ptr<Impl> impl_;
 };
 
 // todo: review

--- a/vesc_driver/include/vesc_driver/vesc_interface.h
+++ b/vesc_driver/include/vesc_driver/vesc_interface.h
@@ -36,20 +36,20 @@
 #ifndef VESC_DRIVER_VESC_INTERFACE_H_
 #define VESC_DRIVER_VESC_INTERFACE_H_
 
-#include <string>
-#include <sstream>
-#include <iostream>
-#include <iomanip>
 #include <exception>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
 #include <stdexcept>
+#include <string>
 
 #include <pthread.h>
+#include <serial/serial.h>
+#include <boost/crc.hpp>
 #include <boost/function.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/crc.hpp>
-#include <serial/serial.h>
 
 #include "vesc_driver/vesc_packet.h"
 #include "vesc_driver/vesc_packet_factory.h"

--- a/vesc_driver/include/vesc_driver/vesc_interface.h
+++ b/vesc_driver/include/vesc_driver/vesc_interface.h
@@ -37,6 +37,7 @@
 #define VESC_DRIVER_VESC_INTERFACE_H_
 
 #include <exception>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -47,7 +48,6 @@
 #include <pthread.h>
 #include <serial/serial.h>
 #include <boost/crc.hpp>
-#include <boost/function.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/scoped_ptr.hpp>
 
@@ -62,8 +62,8 @@ namespace vesc_driver
 class VescInterface : private boost::noncopyable
 {
 public:
-  typedef boost::function<void(const VescPacketConstPtr&)> PacketHandlerFunction;
-  typedef boost::function<void(const std::string&)> ErrorHandlerFunction;
+  typedef std::function<void(const VescPacketConstPtr&)> PacketHandlerFunction;
+  typedef std::function<void(const std::string&)> ErrorHandlerFunction;
 
   /**
    * Creates a VescInterface object. Opens the serial port interface to the VESC if @p port is not

--- a/vesc_driver/include/vesc_driver/vesc_packet.h
+++ b/vesc_driver/include/vesc_driver/vesc_packet.h
@@ -36,15 +36,15 @@
 #ifndef VESC_DRIVER_VESC_PACKET_H_
 #define VESC_DRIVER_VESC_PACKET_H_
 
-#include <string>
-#include <vector>
-#include <utility>
-#include <cstdint>
 #include <cassert>
+#include <cstdint>
 #include <iterator>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <boost/crc.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/distance.hpp>
 #include <boost/range/end.hpp>
@@ -135,14 +135,14 @@ public:
 
 protected:
   VescPacket(const std::string& name, const int16_t payload_size, const int16_t payload_id);
-  VescPacket(const std::string& name, boost::shared_ptr<VescFrame> raw);
+  VescPacket(const std::string& name, std::shared_ptr<VescFrame> raw);
 
 private:
   std::string name_;
 };
 
-typedef boost::shared_ptr<VescPacket> VescPacketPtr;
-typedef boost::shared_ptr<VescPacket const> VescPacketConstPtr;
+typedef std::shared_ptr<VescPacket> VescPacketPtr;
+typedef std::shared_ptr<VescPacket const> VescPacketConstPtr;
 
 /*------------------------------------------------------------------*/
 
@@ -152,7 +152,7 @@ typedef boost::shared_ptr<VescPacket const> VescPacketConstPtr;
 class VescPacketFWVersion : public VescPacket
 {
 public:
-  explicit VescPacketFWVersion(boost::shared_ptr<VescFrame> raw);
+  explicit VescPacketFWVersion(std::shared_ptr<VescFrame> raw);
 
   int16_t fwMajor() const;
   int16_t fwMinor() const;
@@ -177,7 +177,7 @@ public:
 class VescPacketValues : public VescPacket
 {
 public:
-  explicit VescPacketValues(boost::shared_ptr<VescFrame> raw);
+  explicit VescPacketValues(std::shared_ptr<VescFrame> raw);
 
   double getMosTemp() const;
   double getMotorTemp() const;

--- a/vesc_driver/include/vesc_driver/vesc_packet_factory.h
+++ b/vesc_driver/include/vesc_driver/vesc_packet_factory.h
@@ -38,13 +38,13 @@
 
 #include <cassert>
 #include <cstdint>
+#include <functional>
 #include <iterator>
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include <boost/function.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/distance.hpp>
@@ -63,7 +63,7 @@ class VescPacketFactory : private boost::noncopyable
 public:
   static VescPacketPtr createPacket(const Buffer::const_iterator&, const Buffer::const_iterator&, int*, std::string*);
 
-  typedef boost::function<VescPacketPtr(std::shared_ptr<VescFrame>)> CreateFn;
+  typedef std::function<VescPacketPtr(std::shared_ptr<VescFrame>)> CreateFn;
 
   /** Register a packet type with the factory. */
   static void registerPacketType(int, CreateFn);

--- a/vesc_driver/include/vesc_driver/vesc_packet_factory.h
+++ b/vesc_driver/include/vesc_driver/vesc_packet_factory.h
@@ -36,16 +36,16 @@
 #ifndef VESC_DRIVER_VESC_PACKET_FACTORY_H_
 #define VESC_DRIVER_VESC_PACKET_FACTORY_H_
 
-#include <vector>
-#include <map>
-#include <string>
-#include <cstdint>
 #include <cassert>
+#include <cstdint>
 #include <iterator>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
-#include <boost/noncopyable.hpp>
 #include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
+#include <boost/noncopyable.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/distance.hpp>
 #include <boost/range/end.hpp>
@@ -63,7 +63,7 @@ class VescPacketFactory : private boost::noncopyable
 public:
   static VescPacketPtr createPacket(const Buffer::const_iterator&, const Buffer::const_iterator&, int*, std::string*);
 
-  typedef boost::function<VescPacketPtr(boost::shared_ptr<VescFrame>)> CreateFn;
+  typedef boost::function<VescPacketPtr(std::shared_ptr<VescFrame>)> CreateFn;
 
   /** Register a packet type with the factory. */
   static void registerPacketType(int, CreateFn);
@@ -85,7 +85,7 @@ private:
     {                                                                                                                  \
       VescPacketFactory::registerPacketType((id), &klass##Factory::create);                                            \
     }                                                                                                                  \
-    static VescPacketPtr create(boost::shared_ptr<VescFrame> frame)                                                    \
+    static VescPacketPtr create(std::shared_ptr<VescFrame> frame)                                                      \
     {                                                                                                                  \
       return VescPacketPtr(new klass(frame));                                                                          \
     }                                                                                                                  \

--- a/vesc_driver/src/vesc_driver.cpp
+++ b/vesc_driver/src/vesc_driver.cpp
@@ -141,11 +141,11 @@ void VescDriver::timerCallback(const ros::TimerEvent& event)
   }
 }
 
-void VescDriver::vescPacketCallback(const boost::shared_ptr<VescPacket const>& packet)
+void VescDriver::vescPacketCallback(const std::shared_ptr<VescPacket const>& packet)
 {
   if (packet->getName() == "Values")
   {
-    boost::shared_ptr<VescPacketValues const> values = boost::dynamic_pointer_cast<VescPacketValues const>(packet);
+    std::shared_ptr<VescPacketValues const> values = std::dynamic_pointer_cast<VescPacketValues const>(packet);
 
     vesc_msgs::VescStateStamped::Ptr state_msg(new vesc_msgs::VescStateStamped);
     state_msg->header.stamp = ros::Time::now();
@@ -167,8 +167,8 @@ void VescDriver::vescPacketCallback(const boost::shared_ptr<VescPacket const>& p
   }
   else if (packet->getName() == "FWVersion")
   {
-    boost::shared_ptr<VescPacketFWVersion const> fw_version =
-        boost::dynamic_pointer_cast<VescPacketFWVersion const>(packet);
+    std::shared_ptr<VescPacketFWVersion const> fw_version =
+        std::dynamic_pointer_cast<VescPacketFWVersion const>(packet);
     // todo: might need lock here
     fw_version_major_ = fw_version->fwMajor();
     fw_version_minor_ = fw_version->fwMinor();

--- a/vesc_driver/src/vesc_driver.cpp
+++ b/vesc_driver/src/vesc_driver.cpp
@@ -38,8 +38,8 @@
 namespace vesc_driver
 {
 VescDriver::VescDriver(ros::NodeHandle nh, ros::NodeHandle private_nh)
-  : vesc_(std::string(), boost::bind(&VescDriver::vescPacketCallback, this, _1),
-          boost::bind(&VescDriver::vescErrorCallback, this, _1))
+  : vesc_(std::string(), std::bind(&VescDriver::vescPacketCallback, this, std::placeholders::_1),
+          std::bind(&VescDriver::vescErrorCallback, this, std::placeholders::_1))
   , duty_cycle_limit_(private_nh, "duty_cycle", -1.0, 1.0)
   , current_limit_(private_nh, "current")
   , brake_limit_(private_nh, "brake")

--- a/vesc_driver/src/vesc_driver_nodelet.cpp
+++ b/vesc_driver/src/vesc_driver_nodelet.cpp
@@ -33,7 +33,6 @@
  * Corp. takes over development as new packages.
  ********************************************************************/
 
-#include <boost/shared_ptr.hpp>
 #include <nodelet/nodelet.h>
 #include <pluginlib/class_list_macros.h>
 #include <ros/ros.h>
@@ -52,7 +51,7 @@ public:
 private:
   virtual void onInit(void);
 
-  boost::shared_ptr<VescDriver> vesc_driver_;
+  std::shared_ptr<VescDriver> vesc_driver_;
 };  // class VescDriverNodelet
 
 void VescDriverNodelet::onInit()

--- a/vesc_driver/src/vesc_packet.cpp
+++ b/vesc_driver/src/vesc_packet.cpp
@@ -108,7 +108,7 @@ VescPacket::VescPacket(const std::string& name, const int16_t payload_size, cons
  * @param name Packet name
  * @param raw Pointer of a frame
  **/
-VescPacket::VescPacket(const std::string& name, boost::shared_ptr<VescFrame> raw) : VescFrame(*raw), name_(name)
+VescPacket::VescPacket(const std::string& name, std::shared_ptr<VescFrame> raw) : VescFrame(*raw), name_(name)
 {
 }
 
@@ -118,7 +118,7 @@ VescPacket::VescPacket(const std::string& name, boost::shared_ptr<VescFrame> raw
  * @brief Constructor
  * @param raw Pointer of VescFrame
  **/
-VescPacketFWVersion::VescPacketFWVersion(boost::shared_ptr<VescFrame> raw) : VescPacket("FWVersion", raw)
+VescPacketFWVersion::VescPacketFWVersion(std::shared_ptr<VescFrame> raw) : VescPacket("FWVersion", raw)
 {
 }
 
@@ -159,7 +159,7 @@ VescPacketRequestFWVersion::VescPacketRequestFWVersion() : VescPacket("RequestFW
 /**
  * @brief Constructor
  **/
-VescPacketValues::VescPacketValues(boost::shared_ptr<VescFrame> raw) : VescPacket("Values", raw)
+VescPacketValues::VescPacketValues(std::shared_ptr<VescFrame> raw) : VescPacket("Values", raw)
 {
 }
 

--- a/vesc_driver/src/vesc_packet_factory.cpp
+++ b/vesc_driver/src/vesc_packet_factory.cpp
@@ -145,7 +145,7 @@ VescPacketPtr VescPacketFactory::createPacket(const Buffer::const_iterator& begi
     return createFailed(num_bytes_needed, what, "Invalid checksum");
 
   // constructs the raw frame
-  boost::shared_ptr<VescFrame> raw_frame(new VescFrame(view_frame, view_payload));
+  std::shared_ptr<VescFrame> raw_frame(new VescFrame(view_frame, view_payload));
 
   // constructs the corresponding subclass if the packet has a payload
   if (boost::distance(view_payload) > 0)

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
@@ -18,10 +18,9 @@
 #define VESC_HW_INTERFACE_VESC_HW_INTERFACE_H_
 
 #include <cmath>
+#include <functional>
 #include <memory>
 #include <string>
-
-#include <boost/bind.hpp>
 
 #include <controller_manager/controller_manager.h>
 #include <hardware_interface/hardware_interface.h>

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
@@ -17,29 +17,29 @@
 #ifndef VESC_HW_INTERFACE_VESC_HW_INTERFACE_H_
 #define VESC_HW_INTERFACE_VESC_HW_INTERFACE_H_
 
-#include <string>
 #include <cmath>
+#include <memory>
+#include <string>
 
 #include <boost/bind.hpp>
-#include <boost/shared_ptr.hpp>
 
-#include <ros/ros.h>
-#include <serial/serial.h>
+#include <controller_manager/controller_manager.h>
 #include <hardware_interface/hardware_interface.h>
-#include <hardware_interface/robot_hw.h>
-#include <hardware_interface/joint_state_interface.h>
 #include <hardware_interface/joint_command_interface.h>
+#include <hardware_interface/joint_state_interface.h>
+#include <hardware_interface/robot_hw.h>
 #include <joint_limits_interface/joint_limits.h>
 #include <joint_limits_interface/joint_limits_interface.h>
 #include <joint_limits_interface/joint_limits_rosparam.h>
 #include <joint_limits_interface/joint_limits_urdf.h>
-#include <controller_manager/controller_manager.h>
-#include <pluginlib/class_list_macros.hpp>
+#include <ros/ros.h>
+#include <serial/serial.h>
 #include <urdf_parser/urdf_parser.h>
+#include <pluginlib/class_list_macros.hpp>
 
+#include "vesc_driver/vesc_interface.h"
 #include "vesc_driver/vesc_packet.h"
 #include "vesc_driver/vesc_packet_factory.h"
-#include "vesc_driver/vesc_interface.h"
 #include "vesc_hw_interface/vesc_servo_controller.h"
 
 namespace vesc_hw_interface
@@ -83,7 +83,7 @@ private:
   joint_limits_interface::VelocityJointSaturationInterface limit_velocity_interface_;
   joint_limits_interface::EffortJointSaturationInterface limit_effort_interface_;
 
-  void packetCallback(const boost::shared_ptr<VescPacket const>&);
+  void packetCallback(const std::shared_ptr<VescPacket const>&);
   void errorCallback(const std::string&);
 };
 

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -202,11 +202,11 @@ ros::Duration VescHwInterface::getPeriod() const
   return ros::Duration(0.01);
 }
 
-void VescHwInterface::packetCallback(const boost::shared_ptr<VescPacket const>& packet)
+void VescHwInterface::packetCallback(const std::shared_ptr<VescPacket const>& packet)
 {
   if (packet->getName() == "Values")
   {
-    boost::shared_ptr<VescPacketValues const> values = boost::dynamic_pointer_cast<VescPacketValues const>(packet);
+    std::shared_ptr<VescPacketValues const> values = std::dynamic_pointer_cast<VescPacketValues const>(packet);
 
     double current = values->getMotorCurrent();
     double velocity_rpm = values->getRpm();

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -19,8 +19,8 @@
 namespace vesc_hw_interface
 {
 VescHwInterface::VescHwInterface()
-  : vesc_interface_(std::string(), boost::bind(&VescHwInterface::packetCallback, this, _1),
-                    boost::bind(&VescHwInterface::errorCallback, this, _1))
+  : vesc_interface_(std::string(), std::bind(&VescHwInterface::packetCallback, this, std::placeholders::_1),
+                    std::bind(&VescHwInterface::errorCallback, this, std::placeholders::_1))
 {
 }
 


### PR DESCRIPTION
Replace boost-depended codes with STL implemented in C++11. 
This PR does not include functional changes.