### PR TITLE
Unify what gear_ratio means

### DIFF
--- a/vesc_hw_interface/README.md
+++ b/vesc_hw_interface/README.md
@@ -29,11 +29,11 @@ All of following parameters are in `${VESC_HW_INTERFACE_NODE_NAME}/` namespace.
 - `command_mode` (string, **required**): control mode you want to use. Enter one of following parameters: `position`, `velocity`, `effort` and `effort_duty`.
 - `joint_name` (string, *default*: `joint_vesc`): corresponding joint name in your robot URDF.
 - `num_motor_pole_pairs` (double, *default*: 1.0): the number of motor pole pairs.
-- `gear_ratio` (double, *default*: 1.0): ratio of reduction calclated by `joint velocity/motor velocity`.
+- `gear_ratio` (double, *default*: 1.0): ratio of reduction calculated by `joint velocity/motor velocity`.
 - `torque_const` (double, *default*: 1.0): motor torque constant (unit: Nm/A).
 - `robot_description_name` (string, *default*: /robot_description): name of the robot description parameters for loading joint limits
 
-**NOTE**: `gear_ratio` and `torque_const` are used to calclate joint states because VESC generally senses just motor position and motor current, neither joint position nor motor torque.
+**NOTE**: `gear_ratio` and `torque_const` are used to calculate joint states because VESC generally senses just motor position and motor current, neither joint position nor motor torque.
 If your motor unit has other structures, you should implement your own controller.
 
 #### For PID Position Control

--- a/vesc_hw_interface/README.md
+++ b/vesc_hw_interface/README.md
@@ -29,7 +29,7 @@ All of following parameters are in `${VESC_HW_INTERFACE_NODE_NAME}/` namespace.
 - `command_mode` (string, **required**): control mode you want to use. Enter one of following parameters: `position`, `velocity`, `effort` and `effort_duty`.
 - `joint_name` (string, *default*: `joint_vesc`): corresponding joint name in your robot URDF.
 - `num_motor_pole_pairs` (double, *default*: 1.0): the number of motor pole pairs.
-- `gear_ratio` (double, *default*: 1.0): ratio of reduction, which is calclated by joint velocity/motor_velocity.
+- `gear_ratio` (double, *default*: 1.0): ratio of reduction calclated by `joint velocity/motor velocity`.
 - `torque_const` (double, *default*: 1.0): motor torque constant (unit: Nm/A).
 - `robot_description_name` (string, *default*: /robot_description): name of the robot description parameters for loading joint limits
 

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -50,10 +50,6 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
     return false;
   }
 
-  // get the number of motor pole pairs
-  nh.param("num_motor_pole_pairs", num_motor_pole_pairs_, 1);
-  ROS_INFO("The number of motor pole pairs is set to %d", num_motor_pole_pairs_);
-
   // initializes the joint name
   nh.param<std::string>("joint_name", joint_name_, "joint_vesc");
 
@@ -82,6 +78,10 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
   // reads system parameters
   nh.param<double>("gear_ratio", gear_ratio_, 1.0);
   nh.param<double>("torque_const", torque_const_, 1.0);
+  nh.param<int>("num_motor_pole_pairs", num_motor_pole_pairs_, 1);
+  ROS_INFO("Gear ratio is set to %f", gear_ratio_);
+  ROS_INFO("Torque constant is set to %f", torque_const_);
+  ROS_INFO("The number of motor pole pairs is set to %d", num_motor_pole_pairs_);
 
   // reads driving mode setting
   // - assigns an empty string if param. is not found
@@ -175,10 +175,10 @@ void VescHwInterface::write()
     limit_effort_interface_.enforceLimits(getPeriod());
 
     // converts the command unit: Nm or N -> A
-    double ref_current = command_ * gear_ratio_ / torque_const_;
+    const double command_current = command_ * gear_ratio_ / torque_const_;
 
     // sends a reference current command
-    vesc_interface_.setCurrent(ref_current);
+    vesc_interface_.setCurrent(command_current);
   }
   else if (command_mode_ == "effort_duty")
   {


### PR DESCRIPTION
closes #16 

This PR enables us to command reference position, velocity, or torque of **output axis**, i.e. robot joint, by setting `gear_ratio` parameter.