### PR TITLE
[vesc_hw_interface] Use ros::Time::now() in servo loops

### DIFF
--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -29,7 +29,7 @@ using vesc_driver::VescInterface;
 class VescServoController
 {
 public:
-  void init(ros::NodeHandle, VescInterface*, const double);
+  void init(ros::NodeHandle, VescInterface*);
   void control(const double, const double);
   double getZeroPosition() const;
   void executeCalibration();
@@ -46,7 +46,10 @@ private:
   std::string calibration_mode_;  // "duty" or "current" (default: "current")
   double calibration_position_;   // unit: rad or m
   double zero_position_;          // unit: rad or m
-  double Kp_, Ki_, Kd_, frequency_;
+  double Kp_, Ki_, Kd_;
+  double error_previous_;
+  double error_integ_;
+  ros::Time time_previous_;
 
   bool calibrate(const double);
   bool isSaturated(const double) const;

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -104,7 +104,7 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
     limit_position_interface_.registerHandle(limit_handle);
 
     // initializes the servo controller
-    servo_controller_.init(nh, &vesc_interface_, 1.0 / getPeriod().toSec());
+    servo_controller_.init(nh, &vesc_interface_);
   }
   else if (command_mode_ == "velocity")
   {


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary

Use ros::Time::now() to calculate time steps.

## Details

Current implementation uses constant time steps, however, this sometimes causes bad convergence with process delay.

In addition, this PR makes some variables private instead of static.
