### PR TITLE
[vesc_driver] Update indicies to read the latest packet

### DIFF
--- a/vesc_driver/src/vesc_packet.cpp
+++ b/vesc_driver/src/vesc_packet.cpp
@@ -110,6 +110,9 @@ VescPacket::VescPacket(const std::string& name, const int16_t payload_size, cons
  **/
 VescPacket::VescPacket(const std::string& name, std::shared_ptr<VescFrame> raw) : VescFrame(*raw), name_(name)
 {
+  uint16_t original_payload_size = std::distance(payload_end_.first, payload_end_.second);
+  payload_end_.first = frame_.begin() + 2;
+  payload_end_.second = std::min(payload_end_.first + original_payload_size, frame_.end());
 }
 
 /*------------------------------------------------------------------*/


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary
This PR resolves #28 .

## Details
Current implementation has a problem that `payload_end_` is never changed even if `frame_` is updated. It causes failure on reading some values of the VESC status.

## Impacts
<!-- Please describe considerable impacts for other functions -->
None.
