### PR TITLE
[vesc_driver] Fix for reading duty and temp. values

### DIFF
--- a/vesc_driver/src/vesc_driver.cpp
+++ b/vesc_driver/src/vesc_driver.cpp
@@ -154,7 +154,7 @@ void VescDriver::vescPacketCallback(const std::shared_ptr<VescPacket const>& pac
     vesc_msgs::VescStateStamped::Ptr state_msg(new vesc_msgs::VescStateStamped);
     state_msg->header.stamp = ros::Time::now();
     state_msg->state.voltage_input = values->getInputVoltage();
-    state_msg->state.temperature_pcb = values->getMotorTemp();
+    state_msg->state.temperature_pcb = values->getMosTemp();
     state_msg->state.current_motor = values->getMotorCurrent();
     state_msg->state.current_input = values->getInputCurrent();
     state_msg->state.speed = values->getVelocityERPM() / static_cast<double>(num_motor_pole_pairs_) / 60.0 * 2.0 * M_PI;

--- a/vesc_driver/src/vesc_packet.cpp
+++ b/vesc_driver/src/vesc_packet.cpp
@@ -205,7 +205,15 @@ double VescPacketValues::getInputCurrent() const
  **/
 double VescPacketValues::getDuty() const
 {
-  return readBuffer(DUTY_NOW, 2) / 1000.0;
+  int16_t duty_raw = static_cast<int32_t>(readBuffer(DUTY_NOW, 2));
+
+  // inverts to derive a negative value
+  if (duty_raw > 1000)
+  {
+    duty_raw = !duty_raw;
+  }
+
+  return static_cast<double>(duty_raw) / 1000.0;
 }
 
 /**


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary
closes #31 .

## Details
- Correct decoding of duty values
- Use FET temp. instead of motor temp.
  - motor temp. sometimes does not work (I checked this fact with the original VESC Tool).

## Impacts
<!-- Please describe considerable impacts for other functions -->
None.