### PR TITLE
[vesc_driver] Stop a motor when a ROS node dies

### DIFF
--- a/vesc_driver/src/vesc_interface.cpp
+++ b/vesc_driver/src/vesc_interface.cpp
@@ -152,6 +152,9 @@ VescInterface::VescInterface(const std::string& port, const PacketHandlerFunctio
 
 VescInterface::~VescInterface()
 {
+  // stops the motor
+  setDutyCycle(0.0);
+
   disconnect();
 }
 


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary

closes #35 .
This PR adds a motor stop operation when ROS node dies or is killed.

## Details

Since both VescDriver and VescHwInterface send commands via VescInterface, its destructor is suit stopping a motor.

:heavy_check_mark: I have verified that a motor stops immediately after I enter Ctrl+C to kill `vesc_hw_interface_node`.

## Impacts

<!-- Please describe considerable impacts for other functions -->
None.