### PR TITLE
Create control loop for PID

### DIFF
--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -25,15 +25,27 @@
 namespace vesc_hw_interface
 {
 using vesc_driver::VescInterface;
+using vesc_driver::VescPacket;
+using vesc_driver::VescPacketValues;
 
 class VescServoController
 {
 public:
+  VescServoController();
+  ~VescServoController();
+
   void init(ros::NodeHandle, VescInterface*);
   void control(const double, const double);
+  void setTargetPosition(const double position_reference);
+  void setGearRatio(const double gear_ratio);
+  void setTorqueConst(const double torque_const);
+  void setMotorPolePairs(const int motor_pole_pairs);
   double getZeroPosition() const;
+  double getPositionSens(void);
+  double getVelocitySens(void);
+  double getEffortSens(void);
   void executeCalibration();
-
+  void updateSensor(const std::shared_ptr<VescPacket const>&);
 private:
   VescInterface* interface_ptr_;
 
@@ -47,13 +59,25 @@ private:
   double calibration_position_;   // unit: rad or m
   double zero_position_;          // unit: rad or m
   double Kp_, Ki_, Kd_;
+  double control_rate_, control_period_;
+  double position_target_;
+  double position_reference_; // limited with speed (speed_limit_)
+  double position_reference_previous_;
+  double position_sens_, velocity_sens_, effort_sens_;
+  double position_sens_previous_;
   double error_previous_;
   double error_integ_;
   ros::Time time_previous_;
+  int num_motor_pole_pairs_;          // the number of motor pole pairs
+  double gear_ratio_, torque_const_;  // physical params.
+  double speed_limit_;
+  ros::Timer control_timer_;
 
   bool calibrate(const double);
   bool isSaturated(const double) const;
   double saturate(const double) const;
+  void updateSpeedLimitedPositionReference(void);
+  void controlTimerCallback(const ros::TimerEvent& e);
 };
 
 }  // namespace vesc_hw_interface

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -105,6 +105,9 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
 
     // initializes the servo controller
     servo_controller_.init(nh, &vesc_interface_);
+    servo_controller_.setGearRatio(gear_ratio_);
+    servo_controller_.setTorqueConst(torque_const_);
+    servo_controller_.setMotorPolePairs(num_motor_pole_pairs_);
   }
   else if (command_mode_ == "velocity")
   {
@@ -138,7 +141,18 @@ void VescHwInterface::read()
 {
   // requests joint states
   // function `packetCallback` will be called after receiveing retrun packets
-  vesc_interface_.requestState();
+  if (command_mode_ == "position")
+  {
+    // For PID control, request packets are automatically sent in the control cycle.
+    // The latest data is read in this function.
+    position_ = servo_controller_.getPositionSens();
+    velocity_ = servo_controller_.getVelocitySens();
+    effort_   = servo_controller_.getEffortSens();
+  }
+  else
+  {
+    vesc_interface_.requestState();
+  }
 
   return;
 }
@@ -157,7 +171,7 @@ void VescHwInterface::write()
     limit_position_interface_.enforceLimits(getPeriod());
 
     // executes PID control
-    servo_controller_.control(command_, position_);
+    servo_controller_.setTargetPosition(command_);
   }
   else if (command_mode_ == "velocity")
   {
@@ -209,7 +223,11 @@ ros::Duration VescHwInterface::getPeriod() const
 
 void VescHwInterface::packetCallback(const std::shared_ptr<VescPacket const>& packet)
 {
-  if (packet->getName() == "Values")
+  if (command_mode_ == "position")
+  {
+    servo_controller_.updateSensor(packet);
+  }
+  else if (packet->getName() == "Values")
   {
     std::shared_ptr<VescPacketValues const> values = std::dynamic_pointer_cast<VescPacketValues const>(packet);
 

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -18,6 +18,18 @@
 
 namespace vesc_hw_interface
 {
+VescServoController::VescServoController()
+  : gear_ratio_(1.0),
+  torque_const_(1.0),
+  num_motor_pole_pairs_(1)
+{
+}
+
+VescServoController::~VescServoController()
+{
+  interface_ptr_->setDutyCycle(0.0);
+}
+
 void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr)
 {
   // initializes members
@@ -38,10 +50,13 @@ void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr)
   nh.param("servo/Kp", Kp_, 50.0);
   nh.param("servo/Ki", Ki_, 0.0);
   nh.param("servo/Kd", Kd_, 1.0);
+  nh.param("servo/control_rate", control_rate_, 100.0);
+  control_period_ = 1.0 / control_rate_;
   nh.param("servo/calibration_current", calibration_current_, 6.0);
   nh.param("servo/calibration_duty", calibration_duty_, 0.1);
   nh.param<std::string>("servo/calibration_mode", calibration_mode_, "current");
   nh.param("servo/calibration_position", calibration_position_, 0.0);
+  nh.param("servo/speed_limit", speed_limit_, 1.0);
 
   // shows parameters
   ROS_INFO("[Servo Gains] P: %f, I: %f, D: %f", Kp_, Ki_, Kd_);
@@ -57,7 +72,8 @@ void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr)
   {
     ROS_ERROR("[Servo Calibration] Invalid mode");
   }
-
+  // Create timer callback for PID servo control
+  control_timer_ = nh.createTimer(ros::Duration(control_period_), &VescServoController::controlTimerCallback, this);
   return;
 }
 
@@ -67,19 +83,20 @@ void VescServoController::control(const double position_reference, const double 
   if (calibration_flag_)
   {
     calibrate(position_current);
-
     // initializes/resets control variables
     time_previous_ = ros::Time::now();
-    error_previous_ = position_current;
+    position_sens_previous_ = position_current;
+    position_reference_ = calibration_position_;
+    position_reference_previous_ = calibration_position_;
+    error_previous_ = 0.0;
     return;
   }
 
   const ros::Time time_current = ros::Time::now();
-  const double dt = (time_current - time_previous_).toSec();
-
   // calculates PD control
   const double error_current = position_reference - position_current;
-  const double u_pd = Kp_ * error_current + Kd_ * (error_current - error_previous_) / dt;
+  const double u_p = Kp_ * error_current + Kd_;
+  const double u_pd = Kp_ * error_current + Kd_ * (error_current - error_previous_) / control_period_;
 
   double u = 0.0;
 
@@ -90,14 +107,14 @@ void VescServoController::control(const double position_reference, const double 
   }
   else
   {
-    double error_integ_new = error_integ_ + (error_current + error_previous_) / 2.0 * dt;
+    double error_integ_new = error_integ_ + (error_current + error_previous_) / 2.0 * control_period_;
     const double u_pid = u_pd + Ki_ * error_integ_new;
 
     // not use I control if PID input is saturated
     // since error integration causes bugs
     if (isSaturated(u_pid))
     {
-      u = u_pd;
+      u = saturate(u_pid);
     }
     else
     {
@@ -109,11 +126,35 @@ void VescServoController::control(const double position_reference, const double 
   // updates previous data
   error_previous_ = error_current;
   time_previous_ = time_current;
+  position_sens_previous_ = position_current;
+  position_reference_previous_ = position_reference;
 
   // command duty
   interface_ptr_->setDutyCycle(u);
-
   return;
+}
+
+void VescServoController::setTargetPosition(const double position)
+{
+  position_target_ = position;
+}
+
+void VescServoController::setGearRatio(const double gear_ratio)
+{
+  gear_ratio_ = gear_ratio;
+  ROS_INFO("[VescServoController]Gear ratio is set to %f", gear_ratio_);
+}
+
+void VescServoController::setTorqueConst(const double torque_const)
+{
+  torque_const_ = torque_const;
+  ROS_INFO("[VescServoController]Torque constant is set to %f", torque_const_);
+}
+
+void VescServoController::setMotorPolePairs(const int motor_pole_pairs)
+{
+  num_motor_pole_pairs_ = motor_pole_pairs;
+  ROS_INFO("[VescServoController]The number of motor pole pairs is set to %d", num_motor_pole_pairs_);
 }
 
 double VescServoController::getZeroPosition() const
@@ -121,17 +162,35 @@ double VescServoController::getZeroPosition() const
   return zero_position_;
 }
 
+double VescServoController::getPositionSens(void)
+{
+  if (calibration_flag_)
+  {
+    return calibration_position_;
+  }
+  return position_sens_;
+}
+
+double VescServoController::getVelocitySens(void)
+{
+  return velocity_sens_;
+}
+
+double VescServoController::getEffortSens(void)
+{
+  return effort_sens_;
+}
+
 void VescServoController::executeCalibration()
 {
   calibration_flag_ = true;
-
   return;
 }
 
 bool VescServoController::calibrate(const double position_current)
 {
   static double position_previous;
-  static uint16_t step;
+  static uint16_t step = 0;
 
   // sends a command for calibration
   if (calibration_mode_ == CURRENT)
@@ -150,22 +209,31 @@ bool VescServoController::calibrate(const double position_current)
 
   step++;
 
-  if (step % 20 == 0 && position_current == position_previous)
+  if (step % 20 == 0)
   {
-    // finishes calibrating
-    interface_ptr_->setCurrent(0.0);
-    calibration_flag_ = false;
-    step = 0;
-    zero_position_ = position_current - calibration_position_;
-
-    ROS_INFO("Calibration Finished");
-    return true;
+    if(position_current == position_previous)
+    {
+      // finishes calibrating
+      step = 0;
+      zero_position_ = position_current - calibration_position_;
+      position_sens_ = calibration_position_;
+      position_sens_previous_ = calibration_position_;
+      position_target_ = calibration_position_;
+      position_reference_ = calibration_position_;
+      position_reference_previous_ = calibration_position_;
+      ROS_INFO("Calibration Finished");
+      calibration_flag_ = false;
+      return true;
+    }
+    else
+    {
+      position_previous = position_current;
+      return false;
+    }
   }
   else
   {
     // continues calibration
-    position_previous = position_current;
-
     return false;
   }
 }
@@ -198,4 +266,43 @@ double VescServoController::saturate(const double arg) const
   }
 }
 
+void VescServoController::updateSpeedLimitedPositionReference(void)
+{
+  if( position_target_ > (position_reference_previous_ + speed_limit_ * control_period_) )
+  {
+    position_reference_ = position_reference_previous_ + speed_limit_ * control_period_;
+  }
+  else if(position_target_ < (position_reference_previous_ - speed_limit_ * control_period_) )
+  {
+    position_reference_ = position_reference_previous_ - speed_limit_ * control_period_;
+  }
+  else
+  {
+    position_reference_ = position_target_;
+  }
+}
+
+void VescServoController::controlTimerCallback(const ros::TimerEvent& e)
+{
+  updateSpeedLimitedPositionReference();
+  control(position_reference_, position_sens_);
+  interface_ptr_->requestState();
+}
+
+void VescServoController::updateSensor(const std::shared_ptr<VescPacket const>& packet)
+{
+  if (packet->getName() == "Values")
+  {
+    std::shared_ptr<VescPacketValues const> values = std::dynamic_pointer_cast<VescPacketValues const>(packet);
+    const double current = values->getMotorCurrent();
+    const double velocity_rpm = values->getVelocityERPM() / static_cast<double>(num_motor_pole_pairs_);
+    const double position_pulse = values->getPosition();
+    // 3.0 represents the number of hall sensors
+    position_sens_ = position_pulse / num_motor_pole_pairs_ / 3.0 * gear_ratio_ -
+                getZeroPosition();  // unit: rad or m
+    velocity_sens_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;  // unit: rad/s or m/s
+    effort_sens_ = current * torque_const_ / gear_ratio_;             // unit: Nm or N
+  }
+  return;
+}
 }  // namespace vesc_hw_interface

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -95,7 +95,6 @@ void VescServoController::control(const double position_reference, const double 
   const ros::Time time_current = ros::Time::now();
   // calculates PD control
   const double error_current = position_reference - position_current;
-  const double u_p = Kp_ * error_current + Kd_;
   const double u_pd = Kp_ * error_current + Kd_ * (error_current - error_previous_) / control_period_;
 
   double u = 0.0;


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary
The control loop for PID control has been made independent from the Hardware Interface.
It does not affect any operation other than PID servo.

## Details
- fix #34
- fix #37

## Impacts
- The behavior of robots that have been using PID mode may change, so it is necessary to check the operation.

## Additional Information
- The mechanism is different only in PID control mode.
- In the future, it would be better to create a separate hardware interface for PID control. (vesc_pid_hw_interface with pid position control)
