### PR TITLE
velocity duty mode 

### DIFF
--- a/vesc_hw_interface/CMakeLists.txt
+++ b/vesc_hw_interface/CMakeLists.txt
@@ -1,24 +1,23 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(vesc_hw_interface)
 
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  serial
-  hardware_interface
-  joint_limits_interface
-  controller_manager
-  pluginlib
-  urdf
-  vesc_driver
+find_package(
+  catkin REQUIRED
+  COMPONENTS roscpp
+             serial
+             hardware_interface
+             joint_limits_interface
+             controller_manager
+             pluginlib
+             urdf
+             vesc_driver
 )
 
 catkin_package(
-  INCLUDE_DIRS
-    include
-  LIBRARIES
-  ${PROJECT_NAME}
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS
     roscpp
     serial
@@ -36,27 +35,34 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-add_library(${PROJECT_NAME}
+add_library(
+  ${PROJECT_NAME}
   src/vesc_hw_interface.cpp
   src/vesc_servo_controller.cpp
+  src/vesc_wheel_controller.cpp
 )
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
-add_executable(${PROJECT_NAME}_node
-  src/vesc_hw_interface_node.cpp
-)
+add_executable(${PROJECT_NAME}_node src/vesc_hw_interface_node.cpp)
 add_dependencies(${PROJECT_NAME}_node ${catkin_EXPORTED_TARGETS})
-target_link_libraries(${PROJECT_NAME}_node ${catkin_LIBRARIES} ${PROJECT_NAME})
+target_link_libraries(
+  ${PROJECT_NAME}_node
+  ${catkin_LIBRARIES}
+  ${PROJECT_NAME}
+)
 
-install(TARGETS ${PROJECT_NAME}
+install(
+  TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
-install(DIRECTORY include/
+install(
+  DIRECTORY include/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
-install(DIRECTORY launch/
+install(
+  DIRECTORY launch/
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
 )

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 
+#include <angles/angles.h>
 #include <controller_manager/controller_manager.h>
 #include <hardware_interface/hardware_interface.h>
 #include <hardware_interface/joint_command_interface.h>
@@ -33,6 +34,7 @@
 #include <joint_limits_interface/joint_limits_urdf.h>
 #include <ros/ros.h>
 #include <serial/serial.h>
+#include <urdf_model/types.h>
 #include <urdf_parser/urdf_parser.h>
 #include <pluginlib/class_list_macros.hpp>
 
@@ -67,7 +69,7 @@ private:
   VescServoController servo_controller_;
   VescWheelController wheel_controller_;
 
-  std::string joint_name_, command_mode_;
+  std::string joint_name_, command_mode_, joint_type_;
 
   double command_;
   double position_, velocity_, effort_;  // joint states

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
@@ -40,6 +40,7 @@
 #include "vesc_driver/vesc_packet.h"
 #include "vesc_driver/vesc_packet_factory.h"
 #include "vesc_hw_interface/vesc_servo_controller.h"
+#include "vesc_hw_interface/vesc_wheel_controller.h"
 
 namespace vesc_hw_interface
 {
@@ -64,6 +65,7 @@ public:
 private:
   VescInterface vesc_interface_;
   VescServoController servo_controller_;
+  VescWheelController wheel_controller_;
 
   std::string joint_name_, command_mode_;
 

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_wheel_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_wheel_controller.h
@@ -1,0 +1,55 @@
+/*********************************************************************
+ * Copyright (c) 2022 SoftBank Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ********************************************************************/
+
+#ifndef VESC_HW_INTERFACE_VESC_WHEEL_CONTROLLER_H_
+#define VESC_HW_INTERFACE_VESC_WHEEL_CONTROLLER_H_
+
+#include <ros/ros.h>
+#include <vesc_driver/vesc_interface.h>
+
+namespace vesc_hw_interface
+{
+using vesc_driver::VescInterface;
+
+class VescWheelController
+{
+public:
+  void init(ros::NodeHandle nh, VescInterface* vesc_interface);
+  void control(const double target_velocity, const double current_pulse, bool initialize);
+  void setControlFrequency(const double frequency);
+
+private:
+  VescInterface* interface_ptr_;
+
+  double ctrl_frequency_;
+  double kp_, ki_, kd_;
+  double i_clamp_;
+  bool antiwindup_;
+  double duty_limiter_;
+  int num_motor_pole_pairs_;
+
+  double error_, error_dt_, error_integ_, error_integ_prev_;
+  double target_pulse_;
+
+  double counterTD(const double count_in, bool initialize);
+  uint16_t counter_changed_log_[10][2];
+  double counter_td_tmp_[10];
+  uint16_t counter_changed_single_;
+};
+}  // namespace vesc_hw_interface
+
+#endif

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_wheel_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_wheel_controller.h
@@ -24,28 +24,48 @@
 namespace vesc_hw_interface
 {
 using vesc_driver::VescInterface;
+using vesc_driver::VescPacket;
+using vesc_driver::VescPacketValues;
 
 class VescWheelController
 {
 public:
   void init(ros::NodeHandle nh, VescInterface* vesc_interface);
-  void control(const double target_velocity, const double current_pulse, bool initialize);
-  void setControlFrequency(const double frequency);
+  void control(const double target_velocity, const double current_pulse, bool reset);
+  void setTargetVelocity(const double velocity_reference);
+  void setGearRatio(const double gear_ratio);
+  void setTorqueConst(const double torque_const);
+  void setMotorPolePairs(const int motor_pole_pairs);
+  double getPositionSens();
+  double getVelocitySens();
+  double getEffortSens();
+  void updateSensor(const std::shared_ptr<VescPacket const>&);
 
 private:
   VescInterface* interface_ptr_;
 
-  double ctrl_frequency_;
   double kp_, ki_, kd_;
   double i_clamp_;
   bool antiwindup_;
   double duty_limiter_;
-  int num_motor_pole_pairs_;
+  double num_motor_pole_pairs_;
+  double gear_ratio_, torque_const_;
+
+  double control_rate_;
+  ros::Timer control_timer_;
+  void controlTimerCallback(const ros::TimerEvent& e);
+
+  double velocity_reference_;
+  double position_pulse_, prev_position_pulse_;
+  double position_sens_;
+  double velocity_sens_;
+  double effort_sens_;
 
   double error_, error_dt_, error_integ_, error_integ_prev_;
   double target_pulse_;
+  bool reset_;
 
-  double counterTD(const double count_in, bool initialize);
+  double counterTD(const double count_in, bool reset);
   uint16_t counter_changed_log_[10][2];
   double counter_td_tmp_[10];
   uint16_t counter_changed_single_;

--- a/vesc_hw_interface/launch/velocity_control_sample.launch
+++ b/vesc_hw_interface/launch/velocity_control_sample.launch
@@ -10,6 +10,7 @@
     <rosparam>
       joint_name: vesc_joint
       command_mode: velocity
+      joint_type: continuous
       port: /dev/ttyUSB0
       num_motor_pole_pairs: 10
       gear_ratio: 1

--- a/vesc_hw_interface/launch/velocity_duty_control_sample.launch
+++ b/vesc_hw_interface/launch/velocity_duty_control_sample.launch
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- -*- mode: XML -*- -->
+<launch>
+  <!-- Controller -->
+  <arg name="model" default="$(find vesc_hw_interface)/launch/test.xacro"/>
+  <param name="robot_description" command="$(find xacro)/xacro $(arg model)"/>
+
+  <!-- Boot hardware interfaces -->
+  <node name="vesc_hw_interface_node" pkg="vesc_hw_interface" type="vesc_hw_interface_node" output="screen">
+    <rosparam>
+      joint_name: vesc_joint
+      command_mode: velocity_duty
+      port: /dev/ttyUSB0
+      num_motor_pole_pairs: 258
+      gear_ratio: 1
+      torque_const: 1
+      motor:
+        Kp: 0.005
+        Ki: 0.005
+        Kd: 0.0025
+        i_clamp: 0.2
+        duty_limiter: 1.0
+        antiwindup: true
+    </rosparam>
+  </node>
+
+  <!-- Boot ros_controllers -->
+  <rosparam>
+    joint_state_controller:
+      type: joint_state_controller/JointStateController
+      publish_rate: 100
+
+    joint_velocity_controller:
+      type: velocity_controllers/JointVelocityController
+      publish_rate: 100
+      base_frame_id: base_link
+      joint: vesc_joint
+  </rosparam>
+
+  <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="joint_state_controller joint_velocity_controller"/>
+</launch>

--- a/vesc_hw_interface/launch/velocity_duty_control_sample.launch
+++ b/vesc_hw_interface/launch/velocity_duty_control_sample.launch
@@ -10,6 +10,7 @@
     <rosparam>
       joint_name: vesc_joint
       command_mode: velocity_duty
+      joint_type: continuous
       port: /dev/ttyUSB0
       num_motor_pole_pairs: 258
       gear_ratio: 1

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -109,7 +109,7 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
     servo_controller_.setTorqueConst(torque_const_);
     servo_controller_.setMotorPolePairs(num_motor_pole_pairs_);
   }
-  else if (command_mode_ == "velocity")
+  else if (command_mode_ == "velocity" || command_mode_ == "velocity_duty")
   {
     hardware_interface::JointHandle velocity_handle(joint_state_interface_.getHandle(joint_name_), &command_);
     joint_velocity_interface_.registerHandle(velocity_handle);
@@ -117,6 +117,13 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
 
     joint_limits_interface::VelocityJointSaturationHandle limit_handle(velocity_handle, joint_limits_);
     limit_velocity_interface_.registerHandle(limit_handle);
+    if (command_mode_ == "velocity_duty")
+    {
+      wheel_controller_.init(nh, &vesc_interface_);
+      wheel_controller_.setGearRatio(gear_ratio_);
+      wheel_controller_.setTorqueConst(torque_const_);
+      wheel_controller_.setMotorPolePairs(num_motor_pole_pairs_);
+    }
   }
   else if (command_mode_ == "effort" || command_mode_ == "effort_duty")
   {
@@ -140,14 +147,20 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
 void VescHwInterface::read()
 {
   // requests joint states
-  // function `packetCallback` will be called after receiveing retrun packets
+  // function `packetCallback` will be called after receiving return packets
   if (command_mode_ == "position")
   {
     // For PID control, request packets are automatically sent in the control cycle.
     // The latest data is read in this function.
     position_ = servo_controller_.getPositionSens();
     velocity_ = servo_controller_.getVelocitySens();
-    effort_   = servo_controller_.getEffortSens();
+    effort_ = servo_controller_.getEffortSens();
+  }
+  else if (command_mode_ == "velocity_duty")
+  {
+    position_ = wheel_controller_.getPositionSens();
+    velocity_ = wheel_controller_.getVelocitySens();
+    effort_ = wheel_controller_.getEffortSens();
   }
   else
   {
@@ -183,6 +196,13 @@ void VescHwInterface::write()
 
     // sends a reference velocity command
     vesc_interface_.setSpeed(command_erpm);
+  }
+  else if (command_mode_ == "velocity_duty")
+  {
+    limit_velocity_interface_.enforceLimits(getPeriod());
+
+    // executes PID control
+    wheel_controller_.setTargetVelocity(command_);
   }
   else if (command_mode_ == "effort")
   {
@@ -227,6 +247,10 @@ void VescHwInterface::packetCallback(const std::shared_ptr<VescPacket const>& pa
   {
     servo_controller_.updateSensor(packet);
   }
+  else if (command_mode_ == "velocity_duty")
+  {
+    wheel_controller_.updateSensor(packet);
+  }
   else if (packet->getName() == "Values")
   {
     std::shared_ptr<VescPacketValues const> values = std::dynamic_pointer_cast<VescPacketValues const>(packet);
@@ -236,11 +260,9 @@ void VescHwInterface::packetCallback(const std::shared_ptr<VescPacket const>& pa
     const double position_pulse = values->getPosition();
 
     // 3.0 represents the number of hall sensors
-    position_ = position_pulse / num_motor_pole_pairs_ / 3.0 * gear_ratio_ -
-                servo_controller_.getZeroPosition();  // unit: rad or m
-
-    velocity_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;  // unit: rad/s or m/s
-    effort_ = current * torque_const_ / gear_ratio_;             // unit: Nm or N
+    position_ = position_pulse / num_motor_pole_pairs_ / 3.0 * gear_ratio_;  // unit: rad or m
+    velocity_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;              // unit: rad/s or m/s
+    effort_ = current * torque_const_ / gear_ratio_;                         // unit: Nm or N
   }
 
   return;

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -36,6 +36,7 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
   {
     ROS_FATAL("VESC communication port parameter required.");
     ros::shutdown();
+    return false;
   }
 
   // attempts to open the serial port
@@ -46,7 +47,7 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
   catch (serial::SerialException exception)
   {
     ROS_FATAL("Failed to connect to the VESC, %s.", exception.what());
-    // ros::shutdown();
+    ros::shutdown();
     return false;
   }
 
@@ -102,6 +103,16 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
   nh.param<std::string>("command_mode", command_mode_, "");
   ROS_INFO("mode: %s", command_mode_.data());
 
+  // check joint type
+  nh.getParam("joint_type", joint_type_);
+  ROS_INFO("joint type: %s", joint_type_.data());
+  if ((joint_type_ != "revolute") && (joint_type_ != "continuous") && (joint_type_ != "prismatic"))
+  {
+    ROS_ERROR("Verify your joint type");
+    ros::shutdown();
+    return false;
+  }
+
   // registers a state handle and its interface
   hardware_interface::JointStateHandle state_handle(joint_name_, &position_, &velocity_, &effort_);
   joint_state_interface_.registerHandle(state_handle);
@@ -151,15 +162,7 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
   else
   {
     ROS_ERROR("Verify your command mode setting");
-    // ros::shutdown();
-    return false;
-  }
-
-  nh.getParam("joint_type", joint_type_);
-  ROS_INFO("joint type: %s", joint_type_.data());
-  if ((joint_type_ != "revolute") && (joint_type_ != "continuous") && (joint_type_ != "prismatic"))
-  {
-    ROS_ERROR("Verify your joint type");
+    ros::shutdown();
     return false;
   }
 

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -155,7 +155,7 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
     return false;
   }
 
-  nh.param<std::string>("joint_type", joint_type_);
+  nh.getParam("joint_type", joint_type_);
   ROS_INFO("joint type: %s", joint_type_.data());
   if ((joint_type_ != "revolute") && (joint_type_ != "continuous") && (joint_type_ != "prismatic"))
   {

--- a/vesc_hw_interface/src/vesc_wheel_controller.cpp
+++ b/vesc_hw_interface/src/vesc_wheel_controller.cpp
@@ -93,7 +93,8 @@ void VescWheelController::control(const double target_velocity, const double cur
   }
 
   // pid control
-  error_dt_ = target_velocity - (this->counterTD(current_pulse, false) * 2.0 * M_PI / motor_hall_ppr * control_rate_);
+  velocity_sens_ = this->counterTD(current_pulse, false) * 2.0 * M_PI / motor_hall_ppr * control_rate_;
+  error_dt_ = target_velocity - velocity_sens_;
   error_ = target_pulse_ - current_pulse;
   error_integ_prev_ = error_integ_;
   error_integ_ += (error_ / control_rate_);
@@ -246,8 +247,7 @@ void VescWheelController::updateSensor(const std::shared_ptr<const VescPacket>& 
     const double velocity_rpm = values->getVelocityERPM() / static_cast<double>(num_motor_pole_pairs_);
     prev_position_pulse_ = position_pulse_;
     position_pulse_ = values->getPosition();
-    velocity_sens_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;  // unit: rad/s or m/s
-    effort_sens_ = current * torque_const_ / gear_ratio_;             // unit: Nm or N
+    effort_sens_ = current * torque_const_ / gear_ratio_;  // unit: Nm or N
   }
 }
 }  // namespace vesc_hw_interface

--- a/vesc_hw_interface/src/vesc_wheel_controller.cpp
+++ b/vesc_hw_interface/src/vesc_wheel_controller.cpp
@@ -1,0 +1,185 @@
+/*********************************************************************
+ * Copyright (c) 2022 SoftBank Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ********************************************************************/
+
+#include "vesc_hw_interface/vesc_wheel_controller.h"
+
+namespace vesc_hw_interface
+{
+void VescWheelController::init(ros::NodeHandle nh, VescInterface* interface_ptr)
+{
+  if (interface_ptr == NULL)
+  {
+    ros::shutdown();
+  }
+  else
+  {
+    interface_ptr_ = interface_ptr;
+  }
+
+  nh.param<double>("motor/Kp", kp_, 0.005);
+  nh.param<double>("motor/Ki", ki_, 0.005);
+  nh.param<double>("motor/Kd", kd_, 0.0025);
+  nh.param<double>("motor/i_clamp", i_clamp_, 0.2);
+  nh.param<double>("motor/duty_limiter", duty_limiter_, 1.0);
+  nh.param<bool>("motor/antiwindup", antiwindup_, true);
+  ROS_INFO("motor/Kp: %f", kp_);
+  ROS_INFO("motor/Ki: %f", ki_);
+  ROS_INFO("motor/Kd: %f", kd_);
+  ROS_INFO("motor/i_clamp: %f", i_clamp_);
+  ROS_INFO("motor/duty_limiter: %f", duty_limiter_);
+  ROS_INFO("antiwindup: %s", antiwindup_ ? "true" : "false");
+
+  nh.param<int>("num_motor_pole_pairs", num_motor_pole_pairs_, 1.0);
+  ctrl_frequency_ = 50.0;
+}
+
+void VescWheelController::control(const double target_velocity, const double current_pulse, bool initialize)
+{
+  const double motor_hall_ppr = static_cast<double>(num_motor_pole_pairs_);
+  const double count_deviation_limit = static_cast<double>(num_motor_pole_pairs_);
+
+  if (initialize)
+  {
+    target_pulse_ = current_pulse;
+    error_ = 0.0;
+    error_dt_ = 0.0;
+    error_integ_ = 0.0;
+    error_integ_prev_ = 0.0;
+    this->counterTD(current_pulse, true);
+  }
+  else
+  {  // convert rad/s to pulse
+    target_pulse_ += target_velocity * motor_hall_ppr / (2 * M_PI) / ctrl_frequency_;
+  }
+
+  // overflow check
+  if (target_pulse_ > static_cast<double>(LONG_MAX))
+  {
+    target_pulse_ += static_cast<double>(LONG_MIN);
+  }
+  else if (target_pulse_ < static_cast<double>(LONG_MIN))
+  {
+    target_pulse_ += static_cast<double>(LONG_MAX);
+  }
+
+  // limit error
+  if (target_pulse_ - current_pulse > count_deviation_limit)
+  {
+    target_pulse_ = current_pulse + count_deviation_limit;
+  }
+  else if (target_pulse_ - current_pulse < -count_deviation_limit)
+  {
+    target_pulse_ = current_pulse - count_deviation_limit;
+  }
+
+  // pid control
+  error_dt_ = target_velocity - (this->counterTD(current_pulse, false) * 2.0 * M_PI / motor_hall_ppr * ctrl_frequency_);
+  error_ = target_pulse_ - current_pulse;
+  error_integ_prev_ = error_integ_;
+  error_integ_ += (error_ / ctrl_frequency_);
+  double duty = (kp_ * error_ + ki_ * error_integ_ + kd_ * error_dt_);
+
+  if (antiwindup_)
+  {
+    if (duty > duty_limiter_)
+    {
+      duty = duty_limiter_;
+      if (error_integ_ > error_integ_prev_)
+      {
+        error_integ_ = error_integ_prev_;
+        duty = (kp_ * error_ + ki_ * error_integ_ + kd_ * error_dt_);
+      }
+    }
+    else if (duty < -duty_limiter_)
+    {
+      duty = -duty_limiter_;
+      if (error_integ_ < error_integ_prev_)
+      {
+        error_integ_ = error_integ_prev_;
+        duty = (kp_ * error_ + ki_ * error_integ_ + kd_ * error_dt_);
+      }
+    }
+    if (ki_ * error_integ_ > i_clamp_)
+    {
+      error_integ_ = i_clamp_ / ki_;
+    }
+    else if (ki_ * error_integ_ < -i_clamp_)
+    {
+      error_integ_ = -i_clamp_ / ki_;
+    }
+  }
+
+  // limit duty value
+  duty = std::clamp(duty, -duty_limiter_, duty_limiter_);
+  interface_ptr_->setDutyCycle(fabs(target_velocity) < 0.0001 ? 0.0 : duty);
+}
+
+void VescWheelController::setControlFrequency(const double frequency)
+{
+  ctrl_frequency_ = frequency;
+}
+
+double VescWheelController::counterTD(const double count_in, bool initialize)
+{
+  if (initialize)
+  {
+    counter_changed_single_ = 1;
+    for (int i = 0; i < 10; i++)
+    {
+      counter_changed_log_[i][0] = static_cast<uint16_t>(count_in);
+      counter_changed_log_[i][1] = 100;
+      counter_td_tmp_[i] = 0;
+    }
+    return 0.0;
+  }
+
+  if (counter_changed_log_[0][0] != static_cast<uint16_t>(count_in))
+  {
+    for (int i = 0; i < 10; i++)
+    {
+      counter_changed_log_[10 - i][0] = counter_changed_log_[9 - i][0];
+    }
+    counter_changed_log_[0][0] = static_cast<uint16_t>(count_in);
+    counter_changed_log_[0][1] = counter_changed_single_;
+    counter_changed_single_ = 1;
+  }
+  else
+  {
+    if (counter_changed_single_ > counter_changed_log_[0][1])
+    {
+      counter_changed_log_[0][1] = counter_changed_single_;
+    }
+    if (counter_changed_single_ < 100)
+    {
+      counter_changed_single_++;
+    }
+  }
+
+  for (int i = 1; i < 10; i++)
+  {
+    counter_td_tmp_[10 - i] = counter_td_tmp_[9 - i];
+  }
+  counter_td_tmp_[0] = static_cast<double>(counter_changed_log_[0][0] - counter_changed_log_[1][0]) /
+                       static_cast<double>(counter_changed_log_[0][1]);
+  double output = counter_td_tmp_[0];
+  if (fabs(output) > 100.0)
+  {
+    output = 0.0;
+  }
+  return output;
+}
+}  // namespace vesc_hw_interface

--- a/vesc_hw_interface/src/vesc_wheel_controller.cpp
+++ b/vesc_hw_interface/src/vesc_wheel_controller.cpp
@@ -224,10 +224,6 @@ double VescWheelController::getEffortSens()
 
 void VescWheelController::controlTimerCallback(const ros::TimerEvent& e)
 {
-  if (reset_)
-  {
-    prev_position_pulse_ = position_pulse_;
-  }
   double diff = position_pulse_ - prev_position_pulse_;
   if (fabs(diff) > num_motor_pole_pairs_ / 4)
   {


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary
* Added velocity duty command mode for controlling wheel-type vesc motor with duty cycle.
* Added sample launch file to test velocity duty command.
* Check robot's urdf joint type and normalize position between -PI ~ PI if the joint type is revolute.
  * Optionally added `joint_type` parameter to override urdf

## Details

## Impacts
<!-- Please describe considerable impacts for other functions -->

## References
<!-- optional -->

## Additional Information
<!-- optional -->
