### PR TITLE
fix servo sensing calculation

### DIFF
--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
@@ -69,7 +69,8 @@ private:
   VescServoController servo_controller_;
   VescWheelController wheel_controller_;
 
-  std::string joint_name_, command_mode_, joint_type_;
+  std::string joint_name_, command_mode_;
+  int joint_type_;
 
   double command_;
   double position_, velocity_, effort_;  // joint states

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
@@ -76,7 +76,7 @@ private:
 
   int num_rotor_poles_;               // the number of rotor poles
   int num_hall_sensors_;              // the number of hall sensors
-  double gear_ratio_, torque_const_;  // physical params.
+  double gear_ratio_, torque_const_;  // physical params
 
   hardware_interface::JointStateInterface joint_state_interface_;
   hardware_interface::PositionJointInterface joint_position_interface_;

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_hw_interface.h
@@ -78,6 +78,7 @@ private:
   int num_rotor_poles_;               // the number of rotor poles
   int num_hall_sensors_;              // the number of hall sensors
   double gear_ratio_, torque_const_;  // physical params
+  double screw_lead_;                 // linear distance (m) of 1 revolution
 
   hardware_interface::JointStateInterface joint_state_interface_;
   hardware_interface::PositionJointInterface joint_position_interface_;

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include <angles/angles.h>
 #include <ros/ros.h>

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -17,6 +17,7 @@
 #ifndef VESC_HW_INTERFACE_VESC_SERVO_CONTROLLER_H_
 #define VESC_HW_INTERFACE_VESC_SERVO_CONTROLLER_H_
 
+#include <algorithm>
 #include <cmath>
 
 #include <angles/angles.h>

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -19,7 +19,9 @@
 
 #include <cmath>
 
+#include <angles/angles.h>
 #include <ros/ros.h>
+#include <urdf_model/joint.h>
 #include <vesc_driver/vesc_interface.h>
 
 namespace vesc_hw_interface

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -42,6 +42,7 @@ public:
   void setRotorPoles(const int rotor_poles);
   void setHallSensors(const int hall_sensors);
   void setJointType(const int joint_type);
+  void setScrewLead(const double screw_lead);
   double getZeroPosition() const;
   double getPositionSens(void);
   double getVelocitySens(void);
@@ -74,6 +75,7 @@ private:
   int num_rotor_poles_;               // the number of rotor poles
   int num_hall_sensors_;              // the number of hall sensors
   double gear_ratio_, torque_const_;  // physical params
+  double screw_lead_;                 // linear distance (m) of 1 revolution
   int joint_type_;
   double speed_limit_;
   ros::Timer control_timer_;

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -72,7 +72,7 @@ private:
   ros::Time time_previous_;
   int num_rotor_poles_;               // the number of rotor poles
   int num_hall_sensors_;              // the number of hall sensors
-  double gear_ratio_, torque_const_;  // physical params.
+  double gear_ratio_, torque_const_;  // physical params
   double speed_limit_;
   ros::Timer control_timer_;
 

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -41,6 +41,7 @@ public:
   void setTorqueConst(const double torque_const);
   void setRotorPoles(const int rotor_poles);
   void setHallSensors(const int hall_sensors);
+  void setJointType(const int joint_type);
   double getZeroPosition() const;
   double getPositionSens(void);
   double getVelocitySens(void);
@@ -73,6 +74,7 @@ private:
   int num_rotor_poles_;               // the number of rotor poles
   int num_hall_sensors_;              // the number of hall sensors
   double gear_ratio_, torque_const_;  // physical params
+  int joint_type_;
   double speed_limit_;
   ros::Timer control_timer_;
   double position_steps_;

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -78,6 +78,8 @@ private:
   double position_steps_;
   int prev_steps_;
   bool initialize_;
+  int calibration_steps_;
+  double calibration_previous_position_;
 
   bool calibrate(const double);
   bool isSaturated(const double) const;

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -75,6 +75,9 @@ private:
   double gear_ratio_, torque_const_;  // physical params
   double speed_limit_;
   ros::Timer control_timer_;
+  double position_steps_;
+  int prev_steps_;
+  bool initialize_;
 
   bool calibrate(const double);
   bool isSaturated(const double) const;

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -158,6 +158,7 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
     servo_controller_.setTorqueConst(torque_const_);
     servo_controller_.setRotorPoles(num_rotor_poles_);
     servo_controller_.setHallSensors(num_hall_sensors_);
+    servo_controller_.setJointType(joint_type_);
   }
   else if (command_mode_ == "velocity" || command_mode_ == "velocity_duty")
   {

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -299,12 +299,11 @@ void VescHwInterface::packetCallback(const std::shared_ptr<VescPacket const>& pa
 
     const double current = values->getMotorCurrent();
     const double velocity_rpm = values->getVelocityERPM() / static_cast<double>(num_rotor_poles_) / 2;
-    const double position_pulse = values->getPosition();
+    const double steps = values->getPosition();
 
-    // 3.0 represents the number of hall sensors
-    position_ = position_pulse / (num_hall_sensors_ * num_rotor_poles_) * gear_ratio_;  // unit: rad or m
-    velocity_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;                         // unit: rad/s or m/s
-    effort_ = current * torque_const_ / gear_ratio_;                                    // unit: Nm or N
+    position_ = steps / (num_hall_sensors_ * num_rotor_poles_) * gear_ratio_;  // unit: rad or m
+    velocity_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;                // unit: rad/s or m/s
+    effort_ = current * torque_const_ / gear_ratio_;                           // unit: Nm or N
   }
 
   return;

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -94,9 +94,11 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
   nh.param<double>("gear_ratio", gear_ratio_, 1.0);
   nh.param<double>("torque_const", torque_const_, 1.0);
   nh.param<int>("num_hall_sensors", num_hall_sensors_, 3);
+  nh.param<double>("screw_lead", screw_lead_, 1.0);
   ROS_INFO("Gear ratio is set to %f", gear_ratio_);
   ROS_INFO("Torque constant is set to %f", torque_const_);
   ROS_INFO("The number of hall sensors is set to %d", num_hall_sensors_);
+  ROS_INFO("Screw lead is set to %f", screw_lead_);
 
   // check num of rotor poles
   nh.param<int>("num_rotor_poles", num_rotor_poles_, 2);
@@ -159,6 +161,7 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
     servo_controller_.setRotorPoles(num_rotor_poles_);
     servo_controller_.setHallSensors(num_hall_sensors_);
     servo_controller_.setJointType(joint_type_);
+    servo_controller_.setScrewLead(screw_lead_);
   }
   else if (command_mode_ == "velocity" || command_mode_ == "velocity_duty")
   {

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -313,10 +313,24 @@ void VescServoController::updateSensor(const std::shared_ptr<VescPacket const>& 
     position_steps_ += static_cast<double>(steps - prev_steps_);
     prev_steps_ = steps;
 
-    position_sens_ =
-        position_steps_ / (num_hall_sensors_ * num_rotor_poles_) * gear_ratio_ - getZeroPosition();  // unit: revolution
-    velocity_sens_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;                                 // unit: rad/s
+    position_sens_ = position_steps_ / (num_hall_sensors_ * num_rotor_poles_) * gear_ratio_;  // unit: revolution
+    velocity_sens_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;                          // unit: rad/s
     effort_sens_ = current * torque_const_ / gear_ratio_;
+
+    switch (joint_type_)
+    {
+      case urdf::Joint::REVOLUTE:
+        position_sens_ = angles::normalize_angle(position_sens_ * 2.0 * M_PI);  // unit: rad
+        break;
+      case urdf::Joint::CONTINUOUS:
+        position_sens_ = position_sens_ * 2.0 * M_PI;  // unit: rad
+        break;
+      case urdf::Joint::PRISMATIC:
+        position_sens_ = position_sens_ * screw_lead_;  // unit: m
+        break;
+    }
+
+    position_sens_ -= getZeroPosition();
   }
   return;
 }

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -226,7 +226,7 @@ bool VescServoController::calibrate(const double position_current)
 
   if (calibration_steps_ % 20 == 0)
   {
-    if (position_current == calibration_previous_position_)
+    if (std::abs(position_current - calibration_previous_position_) <= std::numeric_limits<double>::epsilon())
     {
       // finishes calibrating
       calibration_steps_ = 0;

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -45,6 +45,8 @@ void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr)
   error_integ_ = 0.0;
   prev_steps_ = 0;
   position_steps_ = 0;
+  calibration_steps_ = 0;
+  calibration_previous_position_ = 0.0;
 
   // reads parameters
   nh.param("servo/Kp", Kp_, 50.0);
@@ -194,9 +196,6 @@ void VescServoController::executeCalibration()
 
 bool VescServoController::calibrate(const double position_current)
 {
-  static double position_previous;
-  static uint16_t step = 0;
-
   // sends a command for calibration
   if (calibration_mode_ == CURRENT)
   {
@@ -212,14 +211,14 @@ bool VescServoController::calibrate(const double position_current)
     return false;
   }
 
-  step++;
+  calibration_steps_++;
 
-  if (step % 20 == 0)
+  if (calibration_steps_ % 20 == 0)
   {
-    if (position_current == position_previous)
+    if (position_current == calibration_previous_position_)
     {
       // finishes calibrating
-      step = 0;
+      calibration_steps_ = 0;
       zero_position_ = position_current - calibration_position_;
       position_sens_ = calibration_position_;
       position_sens_previous_ = calibration_position_;
@@ -232,7 +231,7 @@ bool VescServoController::calibrate(const double position_current)
     }
     else
     {
-      position_previous = position_current;
+      calibration_previous_position_ = position_current;
       return false;
     }
   }

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -76,7 +76,7 @@ void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr)
 
 void VescServoController::control(const double position_reference, const double position_current)
 {
-  // executes caribration
+  // executes calibration
   if (calibration_flag_)
   {
     calibrate(position_current);

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -164,6 +164,11 @@ void VescServoController::setHallSensors(const int hall_sensors)
   ROS_INFO("[VescServoController]The number of hall sensors is set to %d", num_hall_sensors_);
 }
 
+void VescServoController::setJointType(const int joint_type)
+{
+  joint_type_ = joint_type;
+}
+
 double VescServoController::getZeroPosition() const
 {
   return zero_position_;

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -314,19 +314,22 @@ void VescServoController::updateSensor(const std::shared_ptr<VescPacket const>& 
     prev_steps_ = steps;
 
     position_sens_ = position_steps_ / (num_hall_sensors_ * num_rotor_poles_) * gear_ratio_;  // unit: revolution
-    velocity_sens_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;                          // unit: rad/s
+    velocity_sens_ = velocity_rpm * gear_ratio_;                                              // unit: rpm
     effort_sens_ = current * torque_const_ / gear_ratio_;
 
     switch (joint_type_)
     {
       case urdf::Joint::REVOLUTE:
         position_sens_ = angles::normalize_angle(position_sens_ * 2.0 * M_PI);  // unit: rad
+        velocity_sens_ = velocity_sens_ / 60.0 * 2.0 * M_PI;                    // unit: rad/s
         break;
       case urdf::Joint::CONTINUOUS:
-        position_sens_ = position_sens_ * 2.0 * M_PI;  // unit: rad
+        position_sens_ = position_sens_ * 2.0 * M_PI;         // unit: rad
+        velocity_sens_ = velocity_sens_ / 60.0 * 2.0 * M_PI;  // unit: rad/s
         break;
       case urdf::Joint::PRISMATIC:
-        position_sens_ = position_sens_ * screw_lead_;  // unit: m
+        position_sens_ = position_sens_ * screw_lead_;         // unit: m
+        velocity_sens_ = velocity_sens_ / 60.0 * screw_lead_;  // unit: m/s
         break;
     }
 

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -309,9 +309,6 @@ void VescServoController::updateSensor(const std::shared_ptr<VescPacket const>& 
     switch (joint_type_)
     {
       case urdf::Joint::REVOLUTE:
-        position_sens_ = angles::normalize_angle(position_sens_ * 2.0 * M_PI);  // unit: rad
-        velocity_sens_ = velocity_sens_ / 60.0 * 2.0 * M_PI;                    // unit: rad/s
-        break;
       case urdf::Joint::CONTINUOUS:
         position_sens_ = position_sens_ * 2.0 * M_PI;         // unit: rad
         velocity_sens_ = velocity_sens_ / 60.0 * 2.0 * M_PI;  // unit: rad/s

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2019, SoftBank Corp.
+ * Copyright (c) 2022, SoftBank Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,11 @@ void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr)
   }
 
   calibration_flag_ = true;
+  initialize_ = true;
   zero_position_ = 0.0;
   error_integ_ = 0.0;
+  prev_steps_ = 0;
+  position_steps_ = 0;
 
   // reads parameters
   nh.param("servo/Kp", Kp_, 50.0);
@@ -291,11 +294,19 @@ void VescServoController::updateSensor(const std::shared_ptr<VescPacket const>& 
     std::shared_ptr<VescPacketValues const> values = std::dynamic_pointer_cast<VescPacketValues const>(packet);
     const double current = values->getMotorCurrent();
     const double velocity_rpm = values->getVelocityERPM() / static_cast<double>(num_rotor_poles_) / 2;
-    const double steps = values->getPosition();
+    const int steps = static_cast<int>(values->getPosition());
+    if (initialize_)
+    {
+      prev_steps_ = steps;
+      initialize_ = false;
+    }
+    position_steps_ += static_cast<double>(steps - prev_steps_);
+    prev_steps_ = steps;
+
     position_sens_ =
-        steps / (num_hall_sensors_ * num_rotor_poles_) * gear_ratio_ - getZeroPosition();  // unit: rad or m
-    velocity_sens_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;                       // unit: rad/s or m/s
-    effort_sens_ = current * torque_const_ / gear_ratio_;                                  // unit: Nm or N
+        position_steps_ / (num_hall_sensors_ * num_rotor_poles_) * gear_ratio_ - getZeroPosition();  // unit: revolution
+    velocity_sens_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;                                 // unit: rad/s
+    effort_sens_ = current * torque_const_ / gear_ratio_;
   }
   return;
 }

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (c) 2022, SoftBank Corp.
+ * Copyright (c) 2019, SoftBank Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -260,18 +260,7 @@ bool VescServoController::isSaturated(const double arg) const
 
 double VescServoController::saturate(const double arg) const
 {
-  if (arg > 1.0)
-  {
-    return 1.0;
-  }
-  else if (arg < -1.0)
-  {
-    return -1.0;
-  }
-  else
-  {
-    return arg;
-  }
+  return std::clamp(arg, -1.0, 1.0);
 }
 
 void VescServoController::updateSpeedLimitedPositionReference(void)

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -298,11 +298,11 @@ void VescServoController::updateSensor(const std::shared_ptr<VescPacket const>& 
     std::shared_ptr<VescPacketValues const> values = std::dynamic_pointer_cast<VescPacketValues const>(packet);
     const double current = values->getMotorCurrent();
     const double velocity_rpm = values->getVelocityERPM() / static_cast<double>(num_rotor_poles_) / 2;
-    const double position_pulse = values->getPosition();
+    const double steps = values->getPosition();
     position_sens_ =
-        position_pulse / (num_hall_sensors_ * num_rotor_poles_) * gear_ratio_ - getZeroPosition();  // unit: rad or m
-    velocity_sens_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;  // unit: rad/s or m/s
-    effort_sens_ = current * torque_const_ / gear_ratio_;             // unit: Nm or N
+        steps / (num_hall_sensors_ * num_rotor_poles_) * gear_ratio_ - getZeroPosition();  // unit: rad or m
+    velocity_sens_ = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;                       // unit: rad/s or m/s
+    effort_sens_ = current * torque_const_ / gear_ratio_;                                  // unit: Nm or N
   }
   return;
 }

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -88,7 +88,6 @@ void VescServoController::control(const double position_reference, const double 
     // initializes/resets control variables
     time_previous_ = ros::Time::now();
     position_sens_previous_ = position_current;
-    position_reference_ = calibration_position_;
     position_reference_previous_ = calibration_position_;
     error_previous_ = 0.0;
     return;
@@ -231,11 +230,7 @@ bool VescServoController::calibrate(const double position_current)
       // finishes calibrating
       calibration_steps_ = 0;
       zero_position_ = position_current - calibration_position_;
-      position_sens_ = calibration_position_;
-      position_sens_previous_ = calibration_position_;
       position_target_ = calibration_position_;
-      position_reference_ = calibration_position_;
-      position_reference_previous_ = calibration_position_;
       ROS_INFO("Calibration Finished");
       calibration_flag_ = false;
       return true;

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -242,14 +242,7 @@ bool VescServoController::calibrate(const double position_current)
 
 bool VescServoController::isSaturated(const double arg) const
 {
-  if (std::abs(arg) > 1.0)
-  {
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+  return std::abs(arg) > 1.0;
 }
 
 double VescServoController::saturate(const double arg) const

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -169,6 +169,12 @@ void VescServoController::setJointType(const int joint_type)
   joint_type_ = joint_type;
 }
 
+void VescServoController::setScrewLead(const double screw_lead)
+{
+  screw_lead_ = screw_lead;
+  ROS_INFO("[VescServoController]Screw lead is set to %f", screw_lead_);
+}
+
 double VescServoController::getZeroPosition() const
 {
   return zero_position_;


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary
* Probably resolve #42 
* resolve #53 
* resolve #56 
* resolve #59 
* Fix the unit conversion from sensor data and adjust the units for each joint type.
* Replace the static variable with members to avoid the thread-sharing bug

## Details

## Impacts
<!-- Please describe considerable impacts for other functions -->
* Probably need to set the proper parameters and tune PID gain again.

## References
<!-- optional -->

## Additional Information
<!-- optional -->
* Note that this only fixes the sensor calculation and, to an extent, the calibration process.
* This is tested with PRISMATIC joints since we use this often with vesc. 
* REVOLUTION joint is untested. There is still a lot of work needed to be done with this joint type which, if I have time, will be worked on in later PRs. 
