### PR TITLE
Check received data has updated

### DIFF
--- a/vesc_driver/include/vesc_driver/vesc_interface.h
+++ b/vesc_driver/include/vesc_driver/vesc_interface.h
@@ -113,6 +113,12 @@ public:
    * @return Returns true if the serial port is open, false otherwise.
    */
   bool isConnected() const;
+  /**
+   * Returns whether the data has been updated or not.
+   *
+   * @return Returns true if the data has been updated, false otherwise.
+   */
+  bool isRxDataUpdated() const;
 
   /**
    * Send a VESC packet.

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -303,6 +303,10 @@ ros::Duration VescHwInterface::getPeriod() const
 
 void VescHwInterface::packetCallback(const std::shared_ptr<VescPacket const>& packet)
 {
+  if (!vesc_interface_.isRxDataUpdated())
+  {
+    ROS_WARN("[VescHwInterface::packetCallback]packetCallcack called, but no packet received");
+  }
   if (command_mode_ == "position")
   {
     servo_controller_.updateSensor(packet);


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary
Warnings are now displayed when sensor values are not updated.
If vesc is running correctly, this warning will not be displayed.
You can check this at the source code level.
- Fix #64 



## Details

## Impacts
<!-- Please describe considerable impacts for other functions -->

## References
<!-- optional -->

## Additional Information
<!-- optional -->
