### PR TITLE
Save calibration result

### DIFF
--- a/vesc_hw_interface/README.md
+++ b/vesc_hw_interface/README.md
@@ -40,8 +40,17 @@ If your motor unit has other structures, you should implement your own controlle
 - `servo/Kp` (double, *default*: 50.0): proportional gain of the controller.
 - `servo/Ki` (double, *default*: 0.0): integral gain of the controller.
 - `servo/Kd` (double, *default*: 1.0): derivative gain of the controller.
+- `servo/calibration` (bool, *default*: true): if true, the servo will calibrate its origin position.
 - `servo/calibration_current` (double, *default*: 6.0): maximum current used in origin calibration.
 - `servo/calibration_position` (double, *default*: 0.0): the position on which the robot calibrates.
+- `servo/calibration_result_path` (string, *default*: ""): if not empty, the last position will be saved in this path.
+- `servo/last_position` (double, *default*: 0.0): if `calibration` is false, the servo uses this value as its current position.
+
+**Warning**
+
+- If you set `calibration` is true, the servo will move to the limit position with `calibration_current` current. Please make sure that the servo is safe to move.
+- If you set `servo/calibration` is false, the servo will use `servo/last_position` as its current position. If you want to use the last position, you should save the last position in `servo/calibration_result_path` and set `servo/last_position` to the value.
+- If you move the servo manually or by other controllers, you should calibration the servo again.
 
 ### Public Functions
 - `void read()` sends request to get current states, but DOES NOT update immediately. After a return packet comes, the callback function will update private variables.

--- a/vesc_hw_interface/README.md
+++ b/vesc_hw_interface/README.md
@@ -50,7 +50,7 @@ If your motor unit has other structures, you should implement your own controlle
 
 - If you set `calibration` is true, the servo will move to the limit position with `calibration_current` current. Please make sure that the servo is safe to move.
 - If you set `servo/calibration` is false, the servo will use `servo/last_position` as its current position. If you want to use the last position, you should save the last position in `servo/calibration_result_path` and set `servo/last_position` to the value.
-- If you move the servo manually or by other controllers, you should calibration the servo again.
+- If you move the servo manually or use non hardware interface controller or didn't specify the `servo/calibration_result_path`, you should calibrate the servo again.
 
 ### Public Functions
 - `void read()` sends request to get current states, but DOES NOT update immediately. After a return packet comes, the callback function will update private variables.

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -90,6 +90,7 @@ private:
   bool sensor_initialize_;
   int calibration_steps_;
   double calibration_previous_position_;
+  std::string calibration_result_path_;
 
   bool calibrate();
   void controlTimerCallback(const ros::TimerEvent& e);

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -40,7 +40,9 @@ public:
   VescServoController();
   ~VescServoController();
 
-  void init(ros::NodeHandle nh, VescInterface* interface_ptr);
+  void init(ros::NodeHandle nh, VescInterface* interface_ptr, const double gear_ratio = 0.0,
+            const double torque_const = 0.0, const int rotor_poles = 0, const int hall_sensors = 0,
+            const int joint_type = 0, const double screw_lead = 0.0);
   void control();
   void setTargetPosition(const double position);
   void setGearRatio(const double gear_ratio);

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -157,6 +157,9 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
     // initializes the servo controller
     servo_controller_.init(nh, &vesc_interface_, gear_ratio_, torque_const_, num_rotor_poles_, num_hall_sensors_,
                            joint_type_, screw_lead_);
+    position_ = servo_controller_.getPositionSens();
+    velocity_ = servo_controller_.getVelocitySens();
+    effort_ = servo_controller_.getEffortSens();
   }
   else if (command_mode_ == "velocity" || command_mode_ == "velocity_duty")
   {

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -155,13 +155,8 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
     limit_position_interface_.registerHandle(limit_handle);
 
     // initializes the servo controller
-    servo_controller_.init(nh, &vesc_interface_);
-    servo_controller_.setGearRatio(gear_ratio_);
-    servo_controller_.setTorqueConst(torque_const_);
-    servo_controller_.setRotorPoles(num_rotor_poles_);
-    servo_controller_.setHallSensors(num_hall_sensors_);
-    servo_controller_.setJointType(joint_type_);
-    servo_controller_.setScrewLead(screw_lead_);
+    servo_controller_.init(nh, &vesc_interface_, gear_ratio_, torque_const_, num_rotor_poles_, num_hall_sensors_,
+                           joint_type_, screw_lead_);
   }
   else if (command_mode_ == "velocity" || command_mode_ == "velocity_duty")
   {

--- a/vesc_hw_interface/src/vesc_hw_interface_node.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface_node.cpp
@@ -32,19 +32,22 @@ int main(int argc, char** argv)
 
   spinner.start();
 
+  // wait for receiving a vesc packet
+  ros::Duration(1.0).sleep();
+
   while (ros::ok())
   {
-    // sends commands
-    vesc_hw_interface.write(vesc_hw_interface.getTime(), ros::Duration(1.0 / update_rate));
-
-    // updates the hardware interface control
-    controller_manager.update(vesc_hw_interface.getTime(), ros::Duration(1.0 / update_rate));
-
     // gets current states
     vesc_hw_interface.read(vesc_hw_interface.getTime(), ros::Duration(1.0 / update_rate));
 
     // sleeps
     loop_rate.sleep();
+
+    // sends commands
+    vesc_hw_interface.write(vesc_hw_interface.getTime(), ros::Duration(1.0 / update_rate));
+
+    // updates the hardware interface control
+    controller_manager.update(vesc_hw_interface.getTime(), ros::Duration(1.0 / update_rate));
   }
 
   spinner.stop();

--- a/vesc_hw_interface/src/vesc_hw_interface_node.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface_node.cpp
@@ -34,17 +34,17 @@ int main(int argc, char** argv)
 
   while (ros::ok())
   {
-    // gets current states
-    vesc_hw_interface.read(vesc_hw_interface.getTime(), ros::Duration(1.0 / update_rate));
-
-    // sleeps
-    loop_rate.sleep();
-
     // sends commands
     vesc_hw_interface.write(vesc_hw_interface.getTime(), ros::Duration(1.0 / update_rate));
 
     // updates the hardware interface control
     controller_manager.update(vesc_hw_interface.getTime(), ros::Duration(1.0 / update_rate));
+
+    // gets current states
+    vesc_hw_interface.read(vesc_hw_interface.getTime(), ros::Duration(1.0 / update_rate));
+
+    // sleeps
+    loop_rate.sleep();
   }
 
   spinner.stop();

--- a/vesc_hw_interface/src/vesc_hw_interface_node.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface_node.cpp
@@ -32,9 +32,6 @@ int main(int argc, char** argv)
 
   spinner.start();
 
-  // wait for receiving a vesc packet
-  ros::Duration(1.0).sleep();
-
   while (ros::ok())
   {
     // gets current states

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -65,6 +65,11 @@ void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr)
   nh.param<std::string>("servo/calibration_result_path", calibration_result_path_, "servo_calibration_result.yaml");
   if (!calibration_flag_)
   {
+    if (!nh.hasParam("servo/last_position"))
+    {
+      ROS_ERROR("[Servo Control] No last_position parameter found. Please calibrate servo first.");
+      ros::shutdown();
+    }
     nh.param<double>("servo/last_position", target_position_, 0.0);
   }
 

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -62,7 +62,11 @@ void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr)
   nh.param<std::string>("servo/calibration_mode", calibration_mode_, "current");
   nh.param<double>("servo/calibration_position", calibration_position_, 0.0);
   nh.param<bool>("servo/calibration", calibration_flag_, true);
-  nh.param<std::string>("servo/calibration_result_path", calibration_result_path_, "servo_calibration_result.yaml");
+  nh.param<std::string>("servo/calibration_result_path", calibration_result_path_, "");
+  if (!calibration_result_path_.empty())
+  {
+    ROS_INFO("[Servo Control] Latest position will be saved to %s", calibration_result_path_.data());
+  }
   if (!calibration_flag_)
   {
     if (!nh.hasParam("servo/last_position"))
@@ -336,10 +340,13 @@ void VescServoController::updateSensor(const std::shared_ptr<VescPacket const>& 
 
     sens_position_ -= getZeroPosition();
 
-    std::ofstream file;
-    file.open(calibration_result_path_, std::ios::out);
-    file << "servo/last_position: " << sens_position_ << std::endl;
-    file.close();
+    if (!calibration_result_path_.empty())
+    {
+      std::ofstream file;
+      file.open(calibration_result_path_, std::ios::out);
+      file << "servo/last_position: " << sens_position_ << std::endl;
+      file.close();
+    }
   }
   return;
 }


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary

Save the latest position to a file when updating sensor values.
Load the previous position from a file when `servo/calibration` is set to false.

- fix #80 

## Details

## Impacts
<!-- Please describe considerable impacts for other functions -->

## References
<!-- optional -->

## Additional Information
<!-- optional -->
