### PR TITLE
Fix load screw_lead position

### DIFF
--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -56,7 +56,6 @@ CallbackReturn VescHwInterface::on_init(const hardware_interface::HardwareInfo& 
   gear_ratio_ = std::stod(info_.hardware_parameters["gear_ratio"]);
   torque_const_ = std::stod(info_.hardware_parameters["torque_const"]);
   num_hall_sensors_ = std::stoi(info_.hardware_parameters["num_hall_sensors"]);
-  screw_lead_ = std::stod(info_.hardware_parameters["screw_lead"]);
 
   RCLCPP_INFO(rclcpp::get_logger("VescHwInterface"), "Gear ratio is set to %f", gear_ratio_);
   RCLCPP_INFO(rclcpp::get_logger("VescHwInterface"), "Torque constant is set to %f", torque_const_);
@@ -156,6 +155,7 @@ CallbackReturn VescHwInterface::on_configure(const rclcpp_lifecycle::State& /*pr
     servo_controller_.setRotorPoles(num_rotor_poles_);
     servo_controller_.setHallSensors(num_hall_sensors_);
     servo_controller_.setJointType(joint_type_ == "revolute" ? 0 : joint_type_ == "continuous" ? 1 : 2);
+    screw_lead_ = std::stod(info_.hardware_parameters["screw_lead"]);
     servo_controller_.setScrewLead(screw_lead_);
   }
 


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary

Load `screw_lead` when the hw_interface use servo_controller.

- fix #83 

## Details

## Impacts
<!-- Please describe considerable impacts for other functions -->

## References
<!-- optional -->

## Additional Information
<!-- optional -->
