### PR TITLE
option to use external sensor to calibrate vesc position

### DIFF
--- a/vesc_hw_interface/CMakeLists.txt
+++ b/vesc_hw_interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(vesc_hw_interface)
 
 add_compile_options(-std=c++17)
@@ -13,6 +13,8 @@ find_package(
              pluginlib
              urdf
              vesc_driver
+             rosserial_arduino
+             rosserial_client
 )
 
 catkin_package(
@@ -67,3 +69,24 @@ install(
   DIRECTORY launch/
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
 )
+
+rosserial_generate_ros_lib(
+  PACKAGE
+  rosserial_arduino
+  SCRIPT
+  make_libraries.py
+)
+
+rosserial_configure_client(
+  DIRECTORY
+  firmware
+  TOOLCHAIN_FILE
+  ${ROSSERIAL_ARDUINO_TOOLCHAIN}
+)
+
+rosserial_add_client_target(
+  firmware
+  serial_calibration
+  ALL
+)
+rosserial_add_client_target(firmware serial_calibration-upload)

--- a/vesc_hw_interface/firmware/CMakeLists.txt
+++ b/vesc_hw_interface/firmware/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.0.2)
+
+add_definitions(-DUSB_CON)
+
+generate_arduino_firmware(
+  serial_calibration
+  SKETCH
+  pm_t65w_p.ino
+  BOARD
+  nano328 # arduino nano old bootloader
+  PORT
+  /dev/ttyUSB0
+)

--- a/vesc_hw_interface/firmware/pm_t65w_p.ino
+++ b/vesc_hw_interface/firmware/pm_t65w_p.ino
@@ -1,0 +1,17 @@
+#include <Arduino.h>
+
+const int output1Pin = 2;  // black cable -> D2
+bool detected = false;
+
+void setup()
+{
+  Serial.begin(9600);
+  pinMode(output1Pin, INPUT);
+}
+
+void loop()
+{
+  detected = digitalRead(output1Pin);
+  Serial.write(detected);
+  delay(10);
+}

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -23,6 +23,7 @@
 
 #include <angles/angles.h>
 #include <ros/ros.h>
+#include <serial/serial.h>
 #include <urdf_model/joint.h>
 #include <vesc_driver/vesc_interface.h>
 #include <vesc_hw_interface/vesc_step_difference.h>
@@ -66,11 +67,14 @@ private:
   const std::string CURRENT = "current";
 
   bool calibration_flag_;
-  double calibration_current_;    // unit: A
-  double calibration_duty_;       // 0.0 ~ 1.0
-  std::string calibration_mode_;  // "duty" or "current" (default: "current")
-  double calibration_position_;   // unit: rad or m
-  double zero_position_;          // unit: rad or m
+  double calibration_current_;      // unit: A
+  double calibration_duty_;         // 0.0 ~ 1.0
+  std::string calibration_mode_;    // "duty" or "current" (default: "current")
+  bool enable_sensor_calibration_;  // flag to enable calibration using sensor
+  std::string calibration_port_;    // device port to calibration sensor
+  int calibration_baudrate_;        // device baudrate to calibration sensor
+  double calibration_position_;     // unit: rad or m
+  double zero_position_;            // unit: rad or m
   double kp_, ki_, kd_;
   double i_clamp_, duty_limiter_;
   bool antiwindup_;
@@ -96,6 +100,8 @@ private:
 
   bool calibrate();
   void controlTimerCallback(const ros::TimerEvent& e);
+
+  serial::Serial serial_;
 };
 
 }  // namespace vesc_hw_interface

--- a/vesc_hw_interface/launch/position_control_sample.launch
+++ b/vesc_hw_interface/launch/position_control_sample.launch
@@ -29,6 +29,9 @@
         smooth_diff:
           max_sample_sec: 0.2
           max_smooth_step: 10
+        enable_sensor_calibration: false
+        calibration_port: /dev/ttyUSB0
+        calibration_baudrate: 9600
     </rosparam>
   </node>
 

--- a/vesc_hw_interface/package.xml
+++ b/vesc_hw_interface/package.xml
@@ -15,6 +15,8 @@
   <depend>joint_limits_interface</depend>
   <depend>controller_manager</depend>
   <depend>pluginlib</depend>
+  <depend>rosserial_arduino</depend>
+  <depend>rosserial_client</depend>
   <depend>urdf</depend>
   <depend>vesc_driver</depend>
 


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary
- resolve #86 
- I've implemented a function to use an external sensor to calibrate the zero position during command_mode: position (using VESC as servo). For this PR, I used PM-T65W-P photoelectric sensor for calibration.

![test](https://github.com/sbgisen/vesc/assets/7608312/07a4357f-56d7-4cd0-ac67-38a41a775be4)

## Details
1. You can enable calibration via sensor by setting `enable_sensor_calibration: true` Check the vesc_hw_interface/launch/position_control_sample.launch for more parameter details.
2. I've also added sensor calibration firmware. You can load the firmware using Arduino IDE or call the following command. Edit the vesc_hw_interface/firmware/CMakeLists.txt file to change the target port and/or board.
```
catkin build vesc_hw_interface
catkin build --no-deps vesc_hw_interface --make-args vesc_hw_interface_firmware_serial_calibration-upload
```

## Impacts
<!-- Please describe considerable impacts for other functions -->
* Applied new features to vesc_hw_interface as well as introduced additional build dependencies. Make sure to install the necessary dependencies before building
```
roscd vesc_hw_interface
rosdep install --from-paths . -iry
catkin build --this
```

## References
<!-- optional -->

## Additional Information
<!-- optional -->
