### PR TITLE
Add safety function to servo controller

### DIFF
--- a/vesc_hw_interface/README.md
+++ b/vesc_hw_interface/README.md
@@ -41,10 +41,18 @@ If your motor unit has other structures, you should implement your own controlle
 - `servo/Ki` (double, *default*: 0.0): integral gain of the controller.
 - `servo/Kd` (double, *default*: 1.0): derivative gain of the controller.
 - `servo/calibration` (bool, *default*: true): if true, the servo will calibrate its origin position.
+- `servo/calibration_mode` (string, *default*: "current"): the mode of calibration. Enter one of following parameters: `current`, `duty`. If you set `current`, the servo will calibrate its origin position with `calibration_current` and `calibration_strict_current`. If you set `duty`, the servo will calibrate its origin position with `calibration_duty` and `calibration_strict_duty`.
 - `servo/calibration_current` (double, *default*: 6.0): maximum current used in origin calibration.
+- `servo/calibration_strict_current` (double, *default*: same as `calibration_current`): maximum current used in strict origin calibration. If the servo reached the origin position with `calibration_current`, the servo moves slightly away from the origin position and then recalibrates the origin position with `calibration_strict_current`. If `calibration_strict_current` is same as `calibration_current`, the servo will not recalibrate the origin position.
+- `servo/calibration_duty` (double, *default*: 0.1): maximum duty used in origin calibration.
+- `servo/calibration_strict_duty` (double, *default*: same as `calibration_duty`): maximum duty used in strict origin calibration. If the servo reached the origin position with `calibration_duty`, the servo moves slightly away from the origin position and then recalibrates the origin position with `calibration_strict_duty`. If `calibration_strict_duty` is same as `calibration_duty`, the servo will not recalibrate the origin position.
 - `servo/calibration_position` (double, *default*: 0.0): the position on which the robot calibrates.
 - `servo/calibration_result_path` (string, *default*: ""): if not empty, the last position will be saved in this path.
 - `servo/last_position` (double, *default*: 0.0): if `calibration` is false, the servo uses this value as its current position.
+- `servo/use_endstop` (bool, *default*: false): if true, the servo will use the endstop sensor to check the position limit, and the servo subscribes `endstop` topic. You should publish `std_msgs/Bool` message to `endstop` topic. If the message is true, the servo will consider that the servo has reached the endstop.
+- `servo/endstop_margin` (double, *default*: 0.02): the error margin for considering the target_position to have reached the endstop.
+- `servo/endstop_window` (int, *default*: 1): the window size for considering the servo to have reached the endstop.
+- `servo/endstop_threshold` (double, *default*: 0.8): the threshold for considering the servo to have reached the endstop. If the average of most recent `endstop_window` sensor values is greater than `endstop_threshold`, the servo will consider that the servo has reached the endstop.
 
 **Warning**
 

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -26,6 +26,7 @@
 #include <urdf_model/joint.h>
 #include <vesc_driver/vesc_interface.h>
 #include <vesc_hw_interface/vesc_step_difference.h>
+#include <std_msgs/Bool.h>
 
 namespace vesc_hw_interface
 {
@@ -42,7 +43,8 @@ public:
 
   void init(ros::NodeHandle nh, VescInterface* interface_ptr, const double gear_ratio = 0.0,
             const double torque_const = 0.0, const int rotor_poles = 0, const int hall_sensors = 0,
-            const int joint_type = 0, const double screw_lead = 0.0);
+            const int joint_type = 0, const double screw_lead = 0.0, const double upper_limit_position = 0.0,
+            const double lower_limit_position = 0.0);
   void control();
   void setTargetPosition(const double position);
   void setGearRatio(const double gear_ratio);
@@ -94,9 +96,16 @@ private:
   int calibration_steps_;
   double calibration_previous_position_;
   std::string calibration_result_path_;
+  double upper_limit_position_, lower_limit_position_;
+  ros::Subscriber limit_sub_;
+  std::deque<int> limit_deque_;
+  int limit_window_;
+  double limit_ratio_;
+  double limit_margin_;
 
   bool calibrate();
   void controlTimerCallback(const ros::TimerEvent& e);
+  void limit(const std_msgs::Bool::ConstPtr& msg);
 };
 
 }  // namespace vesc_hw_interface

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -68,11 +68,14 @@ private:
   const std::string CURRENT = "current";
 
   bool calibration_flag_;
-  double calibration_current_;    // unit: A
-  double calibration_duty_;       // 0.0 ~ 1.0
-  std::string calibration_mode_;  // "duty" or "current" (default: "current")
-  double calibration_position_;   // unit: rad or m
-  double zero_position_;          // unit: rad or m
+  bool calibration_rewind_;
+  double calibration_current_;         // unit: A
+  double calibration_strict_current_;  // unit: A
+  double calibration_duty_;            // 0.0 ~ 1.0
+  double calibration_strict_duty_;     // 0.0 ~ 1.0
+  std::string calibration_mode_;       // "duty" or "current" (default: "current")
+  double calibration_position_;        // unit: rad or m
+  double zero_position_;               // unit: rad or m
   double kp_, ki_, kd_;
   double i_clamp_, duty_limiter_;
   bool antiwindup_;

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -86,6 +86,7 @@ private:
   double target_position_previous_;
   double sens_position_, sens_velocity_, sens_effort_;
   double position_steps_;
+  double position_resolution_;
   int32_t steps_previous_;
   double error_integ_;
   // Internal variables for initialization

--- a/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/vesc_servo_controller.h
@@ -43,8 +43,8 @@ public:
 
   void init(ros::NodeHandle nh, VescInterface* interface_ptr, const double gear_ratio = 0.0,
             const double torque_const = 0.0, const int rotor_poles = 0, const int hall_sensors = 0,
-            const int joint_type = 0, const double screw_lead = 0.0, const double upper_limit_position = 0.0,
-            const double lower_limit_position = 0.0);
+            const int joint_type = 0, const double screw_lead = 0.0, const double upper_endstop_position = 0.0,
+            const double lower_endstop_position = 0.0);
   void control();
   void setTargetPosition(const double position);
   void setGearRatio(const double gear_ratio);
@@ -99,16 +99,16 @@ private:
   int calibration_steps_;
   double calibration_previous_position_;
   std::string calibration_result_path_;
-  double upper_limit_position_, lower_limit_position_;
-  ros::Subscriber limit_sub_;
-  std::deque<int> limit_deque_;
-  int limit_window_;
-  double limit_ratio_;
-  double limit_margin_;
+  double upper_endstop_position_, lower_endstop_position_;
+  ros::Subscriber endstop_sub_;
+  std::deque<int> endstop_deque_;
+  int endstop_window_;
+  double endstop_threshold_;
+  double endstop_margin_;
 
   bool calibrate();
   void controlTimerCallback(const ros::TimerEvent& e);
-  void limit(const std_msgs::Bool::ConstPtr& msg);
+  void endstopCallback(const std_msgs::Bool::ConstPtr& msg);
 };
 
 }  // namespace vesc_hw_interface

--- a/vesc_hw_interface/launch/position_control_sample.launch
+++ b/vesc_hw_interface/launch/position_control_sample.launch
@@ -29,6 +29,9 @@
         smooth_diff:
           max_sample_sec: 0.2
           max_smooth_step: 10
+        limit_window: 1
+        limit_threshold: 0.8
+        limit_margin: 0.02
     </rosparam>
   </node>
 

--- a/vesc_hw_interface/launch/position_control_sample.launch
+++ b/vesc_hw_interface/launch/position_control_sample.launch
@@ -29,9 +29,9 @@
         smooth_diff:
           max_sample_sec: 0.2
           max_smooth_step: 10
-        limit_window: 1
-        limit_threshold: 0.8
-        limit_margin: 0.02
+        endstop_window: 1
+        endstop_threshold: 0.8
+        endstop_margin: 0.02
     </rosparam>
   </node>
 

--- a/vesc_hw_interface/src/vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/vesc_hw_interface.cpp
@@ -153,10 +153,17 @@ bool VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
 
     joint_limits_interface::PositionJointSaturationHandle limit_handle(position_handle, joint_limits_);
     limit_position_interface_.registerHandle(limit_handle);
+    auto upper_limit = 0.0;
+    auto lower_limit = 0.0;
+    if (joint_limits_.has_position_limits)
+    {
+      upper_limit = joint_limits_.max_position;
+      lower_limit = joint_limits_.min_position;
+    }
 
     // initializes the servo controller
     servo_controller_.init(nh, &vesc_interface_, gear_ratio_, torque_const_, num_rotor_poles_, num_hall_sensors_,
-                           joint_type_, screw_lead_);
+                           joint_type_, screw_lead_, upper_limit, lower_limit);
     position_ = servo_controller_.getPositionSens();
     velocity_ = servo_controller_.getVelocitySens();
     effort_ = servo_controller_.getEffortSens();

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -350,6 +350,15 @@ bool VescServoController::calibrate()
     return false;
   }
 
+  if (std::accumulate(limit_deque_.begin(), limit_deque_.end(), 0.0) != 0.0)
+  {
+    zero_position_ = sens_position_ - calibration_position_;
+    target_position_ = calibration_position_;
+    ROS_INFO("Calibration Finished");
+    calibration_flag_ = false;
+    return true;
+  }
+
   calibration_steps_++;
 
   if (calibration_steps_ % 20 == 0)

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -196,13 +196,9 @@ void VescServoController::control()
     error = 0.0;
     target_vel = 0.0;
     // Wait for target position convergence
-    if (std::fabs(target_position_ - target_position_previous_) < std::numeric_limits<double>::epsilon())
+    if (std::fabs(target_position_ - target_position_previous_) < std::numeric_limits<double>::epsilon() &&
+        std::fabs(target_position_ - upper_limit_position_) < limit_margin_)
     {
-      if (std::fabs(target_position_ - upper_limit_position_) > limit_margin_)
-      {
-        ROS_ERROR("Servo reached upper limit. Please recalibrate the servo.");
-        exit(1);
-      }
       zero_position_ = sens_position_ + zero_position_ - upper_limit_position_;
       sens_position_ = upper_limit_position_;
       ROS_INFO_THROTTLE(10, "[Servo Control] Reset position to %f.", upper_limit_position_);
@@ -215,13 +211,9 @@ void VescServoController::control()
     error = 0.0;
     target_vel = 0.0;
     // Wait for target position convergence
-    if (std::fabs(target_position_ - target_position_previous_) < std::numeric_limits<double>::epsilon())
+    if (std::fabs(target_position_ - target_position_previous_) < std::numeric_limits<double>::epsilon() &&
+        std::fabs(target_position_ - lower_limit_position_) < limit_margin_)
     {
-      if (std::fabs(target_position_ - lower_limit_position_) > limit_margin_)
-      {
-        ROS_ERROR("Servo reached lower limit. Please recalibrate the servo.");
-        exit(1);
-      }
       zero_position_ = sens_position_ + zero_position_ - lower_limit_position_;
       sens_position_ = lower_limit_position_;
       ROS_INFO_THROTTLE(10, "[Servo Control] Reset position to %f.", lower_limit_position_);

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -198,8 +198,8 @@ void VescServoController::control()
 
   double safety_target_position = target_position_;
 
-  auto rate = std::accumulate(endstop_deque_.begin(), endstop_deque_.end(), 0.0) / endstop_deque_.size();
-  if (error > 0 && rate >= endstop_threshold_)
+  auto average = std::accumulate(endstop_deque_.begin(), endstop_deque_.end(), 0.0) / endstop_deque_.size();
+  if (error > 0 && average >= endstop_threshold_)
   {
     ROS_WARN_THROTTLE(10, "[Servo Control] Upper endstop signal received. Stop servo.");
     safety_target_position = sens_position_;
@@ -214,7 +214,7 @@ void VescServoController::control()
       ROS_INFO_THROTTLE(10, "[Servo Control] Reset position to %f.", upper_endstop_position_);
     }
   }
-  else if (error < 0 && rate <= -endstop_threshold_)
+  else if (error < 0 && average <= -endstop_threshold_)
   {
     ROS_WARN_THROTTLE(10, "[Servo Control] Lower endstop signal received. Stop servo.");
     safety_target_position = sens_position_;

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -16,6 +16,8 @@
 
 #include "vesc_hw_interface/vesc_servo_controller.h"
 #include <fstream>
+#include <limits>
+#include <numeric>
 
 namespace vesc_hw_interface
 {
@@ -84,6 +86,17 @@ void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr,
       ros::shutdown();
     }
     nh.param<double>("servo/last_position", target_position_, 0.0);
+  }
+  position_resolution_ = 1.0 / (num_hall_sensors_ * num_rotor_poles_) * gear_ratio_;
+  switch (joint_type_)
+  {
+    case urdf::Joint::REVOLUTE:
+    case urdf::Joint::CONTINUOUS:
+      position_resolution_ = position_resolution_ * 2.0 * M_PI;  // unit: rad
+      break;
+    case urdf::Joint::PRISMATIC:
+      position_resolution_ = position_resolution_ * screw_lead_;  // unit: m
+      break;
   }
 
   // shows parameters
@@ -161,6 +174,10 @@ void VescServoController::control()
   double target_vel = (target_position_ - target_position_previous_) * control_rate_;
 
   double error = target_position_ - sens_position_;
+  if (std::fabs(error) < position_resolution_)
+  {
+    error = 0.0;
+  }
   double error_dt = target_vel - current_vel;
   double error_integ_prev = error_integ_;
   error_integ_ += (error / control_rate_);

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -370,7 +370,7 @@ bool VescServoController::calibrate()
 
   if (std::accumulate(limit_deque_.begin(), limit_deque_.end(), 0.0) != 0.0)
   {
-    zero_position_ = sens_position_ - calibration_position_;
+    zero_position_ = sens_position_ + zero_position_ - calibration_position_;
     if ((calibration_mode_ == CURRENT &&
          std::fabs(calibration_current_ - calibration_strict_current_) < std::numeric_limits<double>::epsilon()) ||
         (calibration_mode_ == DUTY &&

--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -156,6 +156,7 @@ void VescServoController::init(ros::NodeHandle nh, VescInterface* interface_ptr,
   }
 
   limit_sub_ = nh.subscribe("limit", 1, &VescServoController::limit, this);
+  ros::topic::waitForMessage<std_msgs::Bool>("limit", ros::Duration(1.0));
   nh.param<double>("servo/limit_margin", limit_margin_, 0.02);
   nh.param<double>("servo/limit_threshold", limit_ratio_, 0.8);
   nh.param<int>("servo/limit_window", limit_window_, 1);


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary

Subscribe `~limit` topic, and target position set to detected position.
~~and duty set to 0 when the servo reached to limit.~~ To set duty 0, the servo oscillate near by bound of enternal sensor.
- fix #88 

Calibrate servo using the external sensor. (reference #87)
If you calibrate with lower limit position, please be aware that starting the system with the upper limit detected is not intended.
In addition to, add strict mode to calibration using the external sensor.
`servo/calibration_strict_current` and `servo/calibration_strict_duty` are added to rosparam.
These values will be used for recalibration after initially calibrating with `servo/calibration_current` or `servo/calibration_duty`. If not specified, the calibration will only be performed using `servo/calibration_current` or `servo/calibration_duty` as before.
- fix #86 

## Details

## Impacts
<!-- Please describe considerable impacts for other functions -->

## References
<!-- optional -->

## Additional Information
<!-- optional -->
