### PR TITLE
- code for xr1 support

### DIFF
--- a/vesc_driver/include/vesc_driver/vesc_interface.h
+++ b/vesc_driver/include/vesc_driver/vesc_interface.h
@@ -123,7 +123,10 @@ public:
   /**
    * Send a VESC packet.
    */
-  void send(const VescPacket& packet);
+  void send_no_fwd(const VescPacket& packet);
+
+  // RANDEL:: overload for forwarding created packets to can bus address
+  void send(const VescPacket& packet, int fwd_address=-1);
 
   void requestFWVersion();
   void requestState();

--- a/vesc_driver/include/vesc_driver/vesc_packet.h
+++ b/vesc_driver/include/vesc_driver/vesc_packet.h
@@ -43,6 +43,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <iostream>
 
 #include <boost/crc.hpp>
 #include <boost/range/begin.hpp>
@@ -62,6 +63,7 @@ typedef std::pair<Buffer::const_iterator, Buffer::const_iterator> BufferRangeCon
  **/
 class VescFrame
 {
+  friend class VescPacketFwdToCAN;
 public:
   /**
    * @brief Destructor
@@ -78,6 +80,8 @@ public:
   {
     return frame_;
   }
+
+  uint16_t payload_size() const;
 
   /* packet properties */
   static const int16_t VESC_MAX_PAYLOAD_SIZE = 1024;                     // Maximum payload size (bytes)
@@ -273,6 +277,16 @@ class VescPacketSetServoPos : public VescPacket
 {
 public:
   explicit VescPacketSetServoPos(double servo_pos);
+};
+
+/**
+ * @brief packet for forwarding an already constructed packet to a CAN address
+ * 
+ */
+class VescPacketFwdToCAN : public VescPacket
+{
+public:
+  explicit VescPacketFwdToCAN(const VescPacket &packet, uint8_t can_addr);
 };
 
 }  // namespace vesc_driver

--- a/vesc_hw_interface/CMakeLists.txt
+++ b/vesc_hw_interface/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(
   src/vesc_servo_controller.cpp
   src/vesc_wheel_controller.cpp
   src/vesc_step_difference.cpp
+  src/roamer_vesc_hw_interface.cpp
 )
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
@@ -49,6 +50,14 @@ add_executable(${PROJECT_NAME}_node src/vesc_hw_interface_node.cpp)
 add_dependencies(${PROJECT_NAME}_node ${catkin_EXPORTED_TARGETS})
 target_link_libraries(
   ${PROJECT_NAME}_node
+  ${catkin_LIBRARIES}
+  ${PROJECT_NAME}
+)
+
+add_executable(xr1_hw_interface_node src/xr1_hw_interface_node.cpp)
+add_dependencies(xr1_hw_interface_node ${catkin_EXPORTED_TARGETS})
+target_link_libraries(
+  xr1_hw_interface_node
   ${catkin_LIBRARIES}
   ${PROJECT_NAME}
 )

--- a/vesc_hw_interface/include/vesc_hw_interface/roamer_vesc_hw_interface.h
+++ b/vesc_hw_interface/include/vesc_hw_interface/roamer_vesc_hw_interface.h
@@ -1,0 +1,149 @@
+/*********************************************************************
+ * Copyright (c) 2019, SoftBank Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ********************************************************************/
+
+#ifndef XR1_HW_INTERFACE_VESC_HW_INTERFACE_H_
+#define XR1_HW_INTERFACE_VESC_HW_INTERFACE_H_
+
+#include <cmath>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <angles/angles.h>
+#include <controller_manager/controller_manager.h>
+#include <hardware_interface/hardware_interface.h>
+#include <hardware_interface/joint_command_interface.h>
+#include <hardware_interface/joint_state_interface.h>
+#include <hardware_interface/robot_hw.h>
+#include <joint_limits_interface/joint_limits.h>
+#include <joint_limits_interface/joint_limits_interface.h>
+#include <joint_limits_interface/joint_limits_rosparam.h>
+#include <joint_limits_interface/joint_limits_urdf.h>
+#include <ros/ros.h>
+#include <serial/serial.h>
+#include <urdf_model/types.h>
+#include <urdf_parser/urdf_parser.h>
+#include <pluginlib/class_list_macros.hpp>
+
+#include "vesc_driver/vesc_interface.h"
+#include "vesc_driver/vesc_packet.h"
+#include "vesc_driver/vesc_packet_factory.h"
+#include "vesc_hw_interface/vesc_servo_controller.h"
+#include "vesc_hw_interface/vesc_wheel_controller.h"
+
+namespace vesc_hw_interface
+{
+using vesc_driver::VescInterface;
+using vesc_driver::VescPacket;
+using vesc_driver::VescPacketValues;
+
+class XR1VescHwInterface : public hardware_interface::RobotHW
+{
+public:
+  XR1VescHwInterface();
+  ~XR1VescHwInterface();
+
+  bool init(ros::NodeHandle&, ros::NodeHandle&);
+  void read(const ros::Time&, const ros::Duration&);
+  void write(const ros::Time&, const ros::Duration&);
+  ros::Time getTime() const;
+
+private:
+  VescInterface vesc_interface_;
+  VescServoController servo_controller_;
+  VescWheelController wheel_controller_;
+
+  std::string joint_name_, command_mode_;
+  int joint_type_;
+
+  // double command_;
+  // double position_, velocity_, effort_;  // joint states
+  // double command2_;
+  // double position2_, velocity2_, effort2_;  // joint states
+
+  // motors
+  double cmds_[4];            // 4 actuators: (0)front-left, (1)rear-left, (2)front-right, (3)rear-right
+  double p_wheel_pos_[4];     // powered wheels position, indexing same as cmds_[]
+  double p_wheel_vel_[4];     // powered wheels velocity, indexing same as cmds_[]
+  double p_wheel_eff_[4];     // powered wheels effort, indexing same as cmds_[]
+
+  // rocker and bogie sensors
+  double rb_pos_[4];        // rocker position sensor: (0)rocker left, (1)bogie left, (2)rocker right, (3)bogie right
+  double rb_vel_[4];        // rocker velocity sensor
+  double rb_eff_[4];        // rocker effort sensor
+
+  int num_rotor_poles_;               // the number of rotor poles
+  int num_hall_sensors_;              // the number of hall sensors
+  double gear_ratio_, torque_const_;  // physical params
+  double screw_lead_;                 // linear distance (m) of 1 revolution
+
+  hardware_interface::JointStateInterface joint_state_interface_;
+  hardware_interface::PositionJointInterface joint_position_interface_;
+  hardware_interface::VelocityJointInterface joint_velocity_interface_;
+  hardware_interface::EffortJointInterface joint_effort_interface_;
+
+  joint_limits_interface::JointLimits joint_limits_;
+  joint_limits_interface::PositionJointSaturationInterface limit_position_interface_;
+  joint_limits_interface::VelocityJointSaturationInterface limit_velocity_interface_;
+  joint_limits_interface::EffortJointSaturationInterface limit_effort_interface_;
+
+  void packetCallback(const std::shared_ptr<VescPacket const>&);
+  void errorCallback(const std::string&);
+
+  void makeWheelVelInterface(const std::string &joint_name, int cmd_index, const ros::NodeHandle &nh);
+
+  /**
+   * @brief Creates a mock hw velocity + state interface with indeces:
+   * 0: wheel_front_left_joint
+   * 1: wheel_rear_left_joint
+   * 2: wheel_front_right_joint
+   * 3: wheel_rear_right_joint
+   * 
+   * @param joint_name 
+   * @param cmd_index 
+   */
+  void makeMockVelInterface(const std::string &joint_name, int cmd_index);
+  
+  /**
+   * @brief Creates a mock hw state interface with indeces:
+   * 0: rocker_left_joint
+   * 1: bogie_left_joint
+   * 2: rocker_right_joint
+   * 3: bogie_right_joint
+   * 
+   * @param joint_name 
+   * @param cmd_index 
+   */
+  void makeMockStateInterface(const std::string &joint_name, int cmd_index);
+
+  // struct Joint
+  // {
+  //   double position;
+  //   double position_offset;
+  //   double velocity;
+  //   double effort;
+  //   double cmd;
+
+  //   Joint() :
+  //     position(0), velocity(0), effort(0), cmd(0)
+  //   { }
+  // }
+  // joints_[4];
+};
+
+}  // namespace vesc_hw_interface
+
+#endif  // VESC_HW_INTERFACE_VESC_HW_INTERFACE_H_

--- a/vesc_hw_interface/launch/xr6_vesc.launch
+++ b/vesc_hw_interface/launch/xr6_vesc.launch
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- -*- mode: XML -*- -->
+<launch>
+  <!-- Controller -->
+  <!-- <arg name="model" default="$(find vesc_hw_interface)/launch/test.xacro"/>
+  <param name="robot_description" command="$(find xacro)/xacro $(arg model)"/> -->
+  <!-- Boot hardware interfaces -->
+
+  <!-- FOR RIGHT FRONT (MOCK) -->
+  <!-- <node name="mock_hw_interface_node" pkg="vesc_hw_interface" type="mock_hw_interface_node" output="screen" /> -->
+
+
+  <node name="vesc_hw_interface_node" pkg="vesc_hw_interface" type="xr1_hw_interface_node" output="screen">
+    <rosparam>
+      joint_name: wheel_front_left_joint
+      command_mode: velocity
+      joint_type: continuous
+      port: /dev/ttyACM0
+      num_rotor_poles: 14
+      gear_ratio: 1.0
+      torque_const: 1
+    </rosparam>
+  </node>
+
+</launch>

--- a/vesc_hw_interface/src/roamer_vesc_hw_interface.cpp
+++ b/vesc_hw_interface/src/roamer_vesc_hw_interface.cpp
@@ -1,0 +1,394 @@
+/*********************************************************************
+ * Copyright (c) 2019, SoftBank Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ********************************************************************/
+
+#include "vesc_hw_interface/roamer_vesc_hw_interface.h"
+
+namespace vesc_hw_interface
+{
+XR1VescHwInterface::XR1VescHwInterface()
+  : vesc_interface_(std::string(), std::bind(&XR1VescHwInterface::packetCallback, this, std::placeholders::_1),
+                    std::bind(&XR1VescHwInterface::errorCallback, this, std::placeholders::_1))
+{
+}
+
+XR1VescHwInterface::~XR1VescHwInterface()
+{
+}
+
+bool XR1VescHwInterface::init(ros::NodeHandle& nh_root, ros::NodeHandle& nh)
+{
+  // reads a port name to open
+  std::string port;
+  if (!nh.getParam("port", port))
+  {
+    ROS_FATAL("VESC communication port parameter required.");
+    ros::shutdown();
+    return false;
+  }
+
+  // attempts to open the serial port
+  try
+  {
+    vesc_interface_.connect(port);
+  }
+  catch (serial::SerialException exception)
+  {
+    ROS_FATAL("Failed to connect to the VESC, %s.", exception.what());
+    ros::shutdown();
+    return false;
+  }
+
+  // initializes the joint name
+  nh.param<std::string>("joint_name", joint_name_, "joint_vesc");
+
+  // // loads joint limits
+  // std::string robot_description_name, robot_description;
+  // nh.param<std::string>("robot_description_name", robot_description_name, "/robot_description");
+
+  // // parses the urdf and extract joint type
+  // std::string joint_type;
+  // if (nh.getParam(robot_description_name, robot_description))
+  // {
+  //   const urdf::ModelInterfaceSharedPtr urdf = urdf::parseURDF(robot_description);
+  //   const urdf::JointConstSharedPtr urdf_joint = urdf->getJoint(joint_name_);
+
+  //   if (getJointLimits(urdf_joint, joint_limits_))
+  //   {
+  //     ROS_INFO("Joint limits are loaded");
+  //     // fprintf(stderr, "pos_lim: [%d, %f, %f]\n", joint_limits_.has_position_limits, joint_limits_.min_position, joint_limits_.max_position);
+  //     // fprintf(stderr, "vel_lim: [%d, %f]\n", joint_limits_.has_velocity_limits, joint_limits_.max_velocity);
+  //     // fprintf(stderr, "eff_lim: [%d, %f]\n", joint_limits_.has_effort_limits, joint_limits_.max_effort);
+  //     // fprintf(stderr, "acc_lim: [%d, %f]\n", joint_limits_.has_acceleration_limits, joint_limits_.max_acceleration);
+  //     // fprintf(stderr, "jrk_lim: [%d, %f]\n", joint_limits_.has_jerk_limits, joint_limits_.max_jerk);
+  //     // fprintf(stderr, "ang_WA: [%d]\n", joint_limits_.angle_wraparound);
+  //   }
+    
+  //   switch (urdf_joint->type)
+  //   {
+  //     case urdf::Joint::REVOLUTE:
+  //       joint_type = "revolute";
+  //       break;
+  //     case urdf::Joint::CONTINUOUS:
+  //       joint_type = "continuous";
+  //       break;
+  //     case urdf::Joint::PRISMATIC:
+  //       joint_type = "prismatic";
+  //       break;
+  //   }
+  //   // ROS_INFO("RANDEL: Joint: [%s] is (%s)", joint_name_.c_str(), joint_type.c_str());
+  // }
+
+  // **** RANDEL: hardcode limits instead of parsing from URDF so that we can run this BEFORE URDF!!!!
+  std::string joint_type("continuous");
+  joint_limits_.has_velocity_limits = true;
+  joint_limits_.max_velocity = 1000.0;
+  joint_limits_.has_effort_limits = true;
+  joint_limits_.max_effort = 100.0;
+
+  // initializes commands and states
+  // command_ = 0.0;
+  // position_ = 0.0;
+  // velocity_ = 0.0;
+  // effort_ = 0.0;
+
+  // reads system parameters
+  nh.param<double>("gear_ratio", gear_ratio_, 1.0);
+  nh.param<double>("torque_const", torque_const_, 1.0);
+  nh.param<int>("num_hall_sensors", num_hall_sensors_, 3);
+  nh.param<double>("screw_lead", screw_lead_, 1.0);
+  ROS_INFO("Gear ratio is set to %f", gear_ratio_);
+  ROS_INFO("Torque constant is set to %f", torque_const_);
+  ROS_INFO("The number of hall sensors is set to %d", num_hall_sensors_);
+  ROS_INFO("Screw lead is set to %f", screw_lead_);
+
+  // check num of rotor poles
+  nh.param<int>("num_rotor_poles", num_rotor_poles_, 2);
+  ROS_INFO("The number of rotor poles is set to %d", num_rotor_poles_);
+  if (num_rotor_poles_ % 2 != 0)
+  {
+    ROS_ERROR("There should be even number of rotor poles");
+    ros::shutdown();
+    return false;
+  }
+
+  // reads driving mode setting
+  // - assigns an empty string if param. is not found
+  nh.param<std::string>("command_mode", command_mode_, "");
+  ROS_INFO("mode: %s", command_mode_.data());
+
+  // check joint type
+  joint_type_ = urdf::Joint::UNKNOWN;
+  // nh.getParam("joint_type", joint_type);
+  ROS_INFO("joint type: %s", joint_type.data());
+  if (joint_type == "revolute")
+  {
+    joint_type_ = urdf::Joint::REVOLUTE;
+  }
+  else if (joint_type == "continuous")
+  {
+    joint_type_ = urdf::Joint::CONTINUOUS;
+  }
+  else if (joint_type == "prismatic")
+  {
+    joint_type_ = urdf::Joint::PRISMATIC;
+  }
+  if ((joint_type_ != urdf::Joint::REVOLUTE) && (joint_type_ != urdf::Joint::CONTINUOUS) &&
+      (joint_type_ != urdf::Joint::PRISMATIC))
+  {
+    ROS_ERROR("Verify your joint type");
+    ros::shutdown();
+    return false;
+  }
+
+  // registers a state handle and its interface
+  hardware_interface::JointStateHandle state_handle(joint_name_, &p_wheel_pos_[0], &p_wheel_vel_[0], &p_wheel_eff_[0]);
+  joint_state_interface_.registerHandle(state_handle);
+  registerInterface(&joint_state_interface_);
+
+  // registers specified command handle and its interface
+  if (command_mode_ == "velocity" || command_mode_ == "velocity_duty")
+  {
+    hardware_interface::JointHandle velocity_handle(joint_state_interface_.getHandle(joint_name_), &cmds_[0]);
+    joint_velocity_interface_.registerHandle(velocity_handle);
+    registerInterface(&joint_velocity_interface_);
+
+    joint_limits_interface::VelocityJointSaturationHandle limit_handle(velocity_handle, joint_limits_);
+    limit_velocity_interface_.registerHandle(limit_handle);
+    if (command_mode_ == "velocity_duty")
+    {
+      wheel_controller_.init(nh, &vesc_interface_);
+      wheel_controller_.setGearRatio(gear_ratio_);
+      wheel_controller_.setTorqueConst(torque_const_);
+      wheel_controller_.setRotorPoles(num_rotor_poles_);
+      wheel_controller_.setHallSensors(num_hall_sensors_);
+    }
+  }
+  else if (command_mode_ == "effort" || command_mode_ == "effort_duty")
+  {
+    hardware_interface::JointHandle effort_handle(joint_state_interface_.getHandle(joint_name_), &cmds_[0]);
+    joint_effort_interface_.registerHandle(effort_handle);
+    registerInterface(&joint_effort_interface_);
+
+    joint_limits_interface::EffortJointSaturationHandle limit_handle(effort_handle, joint_limits_);
+    limit_effort_interface_.registerHandle(limit_handle);
+  }
+  else
+  {
+    ROS_ERROR("Verify your command mode setting");
+    ros::shutdown();
+    return false;
+  }
+
+
+  // ***************************************************
+  // **** rocker and bogie *****************************
+  // reset
+  memset(cmds_, 0, sizeof(cmds_));
+  memset(p_wheel_pos_, 0, sizeof(p_wheel_pos_));
+  memset(p_wheel_vel_, 0, sizeof(p_wheel_vel_));
+  memset(p_wheel_eff_, 0, sizeof(p_wheel_eff_));
+  memset(rb_pos_, 0, sizeof(rb_pos_));
+  memset(rb_vel_, 0, sizeof(rb_vel_));
+  memset(rb_eff_, 0, sizeof(rb_eff_));
+
+
+  // RANDEL: for mock hw interface
+  makeMockVelInterface(std::string("wheel_rear_left_joint"), 1);
+  makeMockVelInterface(std::string("wheel_front_right_joint"), 2);
+  makeMockVelInterface(std::string("wheel_rear_right_joint"), 3);
+
+  makeMockVelInterface(std::string("wheel_middle_left_joint"), 0);
+  makeMockVelInterface(std::string("wheel_middle_right_joint"), 2);
+
+  makeMockStateInterface(std::string("rocker_left_joint"), 0);
+  makeMockStateInterface(std::string("bogie_left_joint"), 1);
+  makeMockStateInterface(std::string("rocker_right_joint"), 2);
+  makeMockStateInterface(std::string("bogie_right_joint"), 3);
+
+
+  return true;
+}
+
+
+void XR1VescHwInterface::makeWheelVelInterface(const std::string &joint_name, int cmd_index, const ros::NodeHandle &nh){
+  if (command_mode_ == "velocity" || command_mode_ == "velocity_duty")
+  {
+    hardware_interface::JointHandle velocity_handle(joint_state_interface_.getHandle(joint_name.c_str()), &cmds_[cmd_index]);
+    joint_velocity_interface_.registerHandle(velocity_handle);
+    registerInterface(&joint_velocity_interface_);
+
+    joint_limits_interface::VelocityJointSaturationHandle limit_handle(velocity_handle, joint_limits_);
+    limit_velocity_interface_.registerHandle(limit_handle);
+    if (command_mode_ == "velocity_duty")
+    {
+      wheel_controller_.init(nh, &vesc_interface_);
+      wheel_controller_.setGearRatio(gear_ratio_);
+      wheel_controller_.setTorqueConst(torque_const_);
+      wheel_controller_.setRotorPoles(num_rotor_poles_);
+      wheel_controller_.setHallSensors(num_hall_sensors_);
+    }
+  }
+}
+
+void XR1VescHwInterface::makeMockVelInterface(const std::string &joint_name, int cmd_index){
+  hardware_interface::JointStateHandle _state_handle(joint_name.c_str(), &p_wheel_pos_[cmd_index], &p_wheel_vel_[cmd_index], &p_wheel_eff_[cmd_index]);
+  joint_state_interface_.registerHandle(_state_handle);
+  registerInterface(&joint_state_interface_);
+
+  hardware_interface::JointHandle _vel_handle(joint_state_interface_.getHandle(joint_name.c_str()), &cmds_[cmd_index]);
+  joint_velocity_interface_.registerHandle(_vel_handle);
+  registerInterface(&joint_velocity_interface_);
+}
+
+void XR1VescHwInterface::makeMockStateInterface(const std::string &joint_name, int cmd_index){
+  hardware_interface::JointStateHandle _state_handle(joint_name.c_str(), &rb_pos_[cmd_index], &rb_vel_[cmd_index], &rb_eff_[cmd_index]);
+  joint_state_interface_.registerHandle(_state_handle);
+  registerInterface(&joint_state_interface_);
+
+}
+
+void XR1VescHwInterface::read(const ros::Time& time, const ros::Duration& period)
+{
+  // requests joint states
+  // function `packetCallback` will be called after receiving return packets
+  // ROS_INFO("***RANDEL: Readi9ng");
+  /*if (command_mode_ == "position")
+  {
+    // For PID control, request packets are automatically sent in the control cycle.
+    // The latest data is read in this function.
+    position_ = servo_controller_.getPositionSens();
+    velocity_ = servo_controller_.getVelocitySens();
+    effort_ = servo_controller_.getEffortSens();
+  }
+  else*/ if (command_mode_ == "velocity_duty")
+  {
+    p_wheel_pos_[0] = wheel_controller_.getPositionSens();
+    p_wheel_vel_[0] = wheel_controller_.getVelocitySens();
+    p_wheel_eff_[0] = wheel_controller_.getEffortSens();
+  }
+  else
+  {
+    // ROS_INFO("***RANDEL: requesting state!");
+    vesc_interface_.requestState();
+  }
+
+  // ROS_INFO("***RANDEL: joint: %d", joint_type_);
+  if (joint_type_ == urdf::Joint::REVOLUTE || joint_type_ == urdf::Joint::CONTINUOUS)
+  {
+    p_wheel_pos_[0] = angles::normalize_angle(p_wheel_pos_[0]);
+    // ROS_INFO("***RANDEL: uuuuuu %f", position_);
+  }
+
+  return;
+}
+
+void XR1VescHwInterface::write(const ros::Time& time, const ros::Duration& period)
+{
+  // sends commands
+  if (command_mode_ == "position")
+  {
+    // Limit the speed using the parameters listed in xacro
+    limit_position_interface_.enforceLimits(period);
+
+    // executes PID control
+    servo_controller_.setTargetPosition(cmds_[0]);
+  }
+  else if (command_mode_ == "velocity")
+  {
+    limit_velocity_interface_.enforceLimits(period);
+
+    // converts the velocity unit: rad/s or m/s -> rpm -> erpm
+    const double command_rpm = cmds_[0] * 60.0 / 2.0 / M_PI / gear_ratio_;
+    const double command_erpm = command_rpm * static_cast<double>(num_rotor_poles_) / 2;
+
+
+    // fprintf(stderr, "****CMDDDD: %f, %f\n", command_, command_erpm);
+    // sends a reference velocity command
+    vesc_interface_.setSpeed(command_erpm);
+  }
+  else if (command_mode_ == "velocity_duty")
+  {
+    limit_velocity_interface_.enforceLimits(period);
+
+    // executes PID control
+    wheel_controller_.setTargetVelocity(cmds_[0]);
+  }
+  else if (command_mode_ == "effort")
+  {
+    limit_effort_interface_.enforceLimits(period);
+
+    // converts the command unit: Nm or N -> A
+    const double command_current = cmds_[0] * gear_ratio_ / torque_const_;
+
+    // sends a reference current command
+    vesc_interface_.setCurrent(command_current);
+  }
+  else if (command_mode_ == "effort_duty")
+  {
+    cmds_[0] = std::max(-1.0, cmds_[0]);
+    cmds_[0] = std::min(1.0, cmds_[0]);
+
+    // sends a  duty command
+    vesc_interface_.setDutyCycle(cmds_[0]);
+  }
+  return;
+}
+
+ros::Time XR1VescHwInterface::getTime() const
+{
+  return ros::Time::now();
+}
+
+void XR1VescHwInterface::packetCallback(const std::shared_ptr<VescPacket const>& packet)
+{
+  // ROS_INFO("***RANDEL: packetCallback CALLED!!!");
+  if (!vesc_interface_.isRxDataUpdated())
+  {
+    ROS_WARN("[XR1VescHwInterface::packetCallback]packetCallcack called, but no packet received");
+  }
+  if (command_mode_ == "position")
+  {
+    servo_controller_.updateSensor(packet);
+  }
+  else if (command_mode_ == "velocity_duty")
+  {
+    wheel_controller_.updateSensor(packet);
+  }
+  else if (packet->getName() == "Values")
+  {
+    std::shared_ptr<VescPacketValues const> values = std::dynamic_pointer_cast<VescPacketValues const>(packet);
+
+    const double current = values->getMotorCurrent();
+    const double velocity_rpm = values->getVelocityERPM() / static_cast<double>(num_rotor_poles_ / 2);
+    const double steps = values->getPosition();
+
+    p_wheel_pos_[0] = steps / (num_hall_sensors_ * num_rotor_poles_) * gear_ratio_;  // unit: rad or m
+    p_wheel_vel_[0] = velocity_rpm / 60.0 * 2.0 * M_PI * gear_ratio_;                // unit: rad/s or m/s
+    p_wheel_eff_[0] = current * torque_const_ / gear_ratio_;                           // unit: Nm or N
+  }
+
+  return;
+}
+
+void XR1VescHwInterface::errorCallback(const std::string& error)
+{
+  ROS_ERROR("%s", error.c_str());
+  return;
+}
+
+}  // namespace vesc_hw_interface
+
+PLUGINLIB_EXPORT_CLASS(vesc_hw_interface::XR1VescHwInterface, hardware_interface::RobotHW)

--- a/vesc_hw_interface/src/xr1_hw_interface_node.cpp
+++ b/vesc_hw_interface/src/xr1_hw_interface_node.cpp
@@ -1,0 +1,54 @@
+/*********************************************************************
+ * Copyright (c) 2019, SoftBank Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ********************************************************************/
+
+#include "vesc_hw_interface/roamer_vesc_hw_interface.h"
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "xr1_hw_interface_node");
+
+  ros::NodeHandle nh, nh_private("~");
+  vesc_hw_interface::XR1VescHwInterface xr1_vesc_hw_interface;
+  xr1_vesc_hw_interface.init(nh, nh_private);
+
+  controller_manager::ControllerManager controller_manager(&xr1_vesc_hw_interface, nh);
+
+  double update_rate = 100;
+  double update_duration = 1.0 / update_rate;
+  ros::Rate loop_rate(update_rate);
+  ros::AsyncSpinner spinner(1);
+
+  spinner.start();
+
+  while (ros::ok())
+  {
+    // sends commands
+    xr1_vesc_hw_interface.write(xr1_vesc_hw_interface.getTime(), ros::Duration(update_duration));
+
+    // updates the hardware interface control
+    controller_manager.update(xr1_vesc_hw_interface.getTime(), ros::Duration(update_duration));
+
+    // gets current states
+    xr1_vesc_hw_interface.read(xr1_vesc_hw_interface.getTime(), ros::Duration(update_duration));
+
+    // sleeps
+    loop_rate.sleep();
+  }
+
+  spinner.stop();
+
+  return 0;
+}

--- a/vesc_hw_interface/vesc_hw_interface_plugin.xml
+++ b/vesc_hw_interface/vesc_hw_interface_plugin.xml
@@ -4,4 +4,11 @@
         plugin of VESC hardware interface
     </description>
   </class>
+
+  <class name="vesc_hw_interface/XR1VescHwInterface" type="vesc_hw_interface::XR1VescHwInterface" base_class_type="hardware_interface::RobotHW">
+    <description>
+        XR1 plugin of VESC hardware interface
+    </description>
+  </class>
+  
 </library>


### PR DESCRIPTION
- working for xr1 uart direct and canbus forwarding (roamer_vesc_hw_interface.cpp/h, and its node, xr6_vesc.launch) -- has dummy hw velocity interfaces, for testing
-- modified VescInterface::send() to accomodate can forwarding -- renamed old VescInterface::send() to VescInterface::send_no_fwd() -- modified vesc_pachet.cpp

<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary

## Details

## Impacts
<!-- Please describe considerable impacts for other functions -->

## References
<!-- optional -->

## Additional Information
<!-- optional -->
