### PR TITLE
Fix node name

### DIFF
--- a/vesc_hw_interface/src/vesc_servo_controller.cpp
+++ b/vesc_hw_interface/src/vesc_servo_controller.cpp
@@ -177,7 +177,11 @@ void VescServoController::init(hardware_interface::HardwareInfo& info,
   if (use_endstop)
   {
     rclcpp::NodeOptions options;
-    options.arguments({ "--ros-args", "-r", "__node:=" + info.name + "_endstop" });
+    std::string endstop_receiver_name = info.name + "_endstop_receiver";
+    std::transform(
+      endstop_receiver_name.begin(), endstop_receiver_name.end(), endstop_receiver_name.begin(),
+      [](unsigned char c) { return std::tolower(c); });
+    options.arguments({"--ros-args", "-r", "__node:=" + endstop_receiver_name});
     node_ = rclcpp::Node::make_shared("_", options);
     endstop_sub_ = node_->create_subscription<std_msgs::msg::Bool>(
         "endstop", rclcpp::SensorDataQoS(),


### PR DESCRIPTION
<!-- Although you had better to fill up the following, -->
<!-- you can submit a PR with any styles if the PR includes enough information. -->

## Change Summary

Fix the name of the endstop sensor receiving node.

- fix #109 

## Details

- Changed the name to follow the format `[hardware_name]_endstop_receiver`.  
- Ensured that the name is in all lowercase and follows the snake_case convention.

## Impacts
<!-- Please describe considerable impacts for other functions -->

## References
<!-- optional -->

## Additional Information
<!-- optional -->
